### PR TITLE
Fleet visibility (v, vbat_mV, rssi) + ESP32-S3-Zero port + HTTP-pull OTA

### DIFF
--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -1,7 +1,7 @@
 ---
 name: router
 description: Session bootstrap and navigation hub. Read at the start of every session before any task.
-last_updated: 2026-04-25 (sensor-tag-wifi HTTP-pull OTA happy-path validated end-to-end on c5fffe12; tag deployed to yard on 5423c04; Battery::percentFromMillivolts extracted inline + 6 native tests added on ceb0fa4; truncation contract test added → 37 native tests on 0285a16; payload extended with v/vbat_mV/rssi fields → 38 native tests on 7f8d628; RingBuffer MAGIC bumped 0xCB50A001→0xCB50A002 + Reading static_assert added on 31de751; vbat_mV wired at sample time + RSSI captured post-connect and forwarded to publish on 12d8fab)
+last_updated: 2026-04-25 (sensor-tag-wifi HTTP-pull OTA happy-path validated end-to-end on c5fffe12; tag deployed to yard on 5423c04; Battery::percentFromMillivolts extracted inline + 6 native tests added on ceb0fa4; truncation contract test added → 37 native tests on 0285a16; payload extended with v/vbat_mV/rssi fields → 38 native tests on 7f8d628; RingBuffer MAGIC bumped 0xCB50A001→0xCB50A002 + Reading static_assert added on 31de751; vbat_mV wired at sample time + RSSI captured post-connect and forwarded to publish on 12d8fab; dead Battery::readPercent dropped + RSSI cast documented on 4fb0541)
 ---
 
 ## Infrastructure
@@ -75,6 +75,7 @@ Read this file fully before doing anything else in this session.
   - **Validated 2026-04-25:** tag c5fffe12 OTA'd a720183 → 5423c04 end-to-end (download 1,056,480 B, sha256 verified, reboot, new fw published over MQTT, sleep 300s). Tag deployed to yard. Tasks 15b–15e (sha-mismatch / auto-rollback / low-battery skip / failed-version pin) still need bench validation.
 - **TSDB stack** (`combsense-tsdb` LXC, `deploy/tsdb/` for canonical configs)
   - Telegraf MQTT → Influx pipeline, arrival-time stamped, firmware `t` preserved as `sensor_ts` field
+  - sensor-tag-wifi fleet-visibility fields parsed (`v`→`fw_version` string, `vbat_mV` int, `rssi` int) — all `optional=true` so older payloads still parse during rollout
   - Downsample tasks: 15m cadence into `combsense_1h`, 6h cadence from `_1h` into `combsense_1d`
   - Daily `influx backup` via systemd timer, 14-day retention on disk
 - **iOS history feature** (in `sjordan0228/combsense`)

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -1,7 +1,7 @@
 ---
 name: router
 description: Session bootstrap and navigation hub. Read at the start of every session before any task.
-last_updated: 2026-04-25 (sensor-tag-wifi HTTP-pull OTA shipped — manifest+sha256 over LAN nginx; pending hardware smoke tests)
+last_updated: 2026-04-25 (sensor-tag-wifi HTTP-pull OTA happy-path validated end-to-end on c5fffe12; tag deployed to yard on 5423c04)
 ---
 
 ## Infrastructure
@@ -67,7 +67,10 @@ Read this file fully before doing anything else in this session.
   - Epoch timestamps via NTP sync in `drainBuffer()` — persists across deep sleep via RTC; pre-sync readings emit `t=0` which Telegraf replaces with arrival time
   - NaN temperatures serialize as JSON `null` (not `nan`) so Telegraf/Swift/Postgres parsers accept them
   - USB-CDC serial console provisioning (WiFi/MQTT/OTA creds via `tools/provision_tag.py --ota-host ...`)
-  - HTTP-pull OTA on wake (manifest at `http://192.168.1.61/firmware/sensor-tag-wifi/<variant>/manifest.json`, sha256-verified, dual 1.5 MB OTA slots, bootloader auto-rollback if first publish after flash fails). Publish via `deploy/web/publish-firmware.sh <sht31|ds18b20>`. nginx LAN-only allowlist on combsense-web LXC.
+  - HTTP-pull OTA on wake (manifest at `http://192.168.1.61/firmware/sensor-tag-wifi/<variant>/manifest.json`, sha256-verified, dual 1.5 MB OTA slots, bootloader auto-rollback if first publish after flash fails). Publish via `deploy/web/publish-firmware.sh <sht31|ds18b20|s3-ds18b20>`. nginx LAN-only allowlist on combsense-web LXC.
+  - **Hardware variants:** Seeed XIAO ESP32-C6 (default; envs `xiao-c6-sht31`, `xiao-c6-ds18b20`) and Waveshare ESP32-S3-Zero (env `waveshare-s3zero-ds18b20`, OTA variant `s3-ds18b20`). Pin map differs (S3: OneWire→GPIO4, batt ADC→GPIO1) via build-flag overrides in `include/config.h`. S3 board flagged as `esp32-s3-devkitc-1` because `waveshare_esp32_s3_zero` is not in the pioarduino board index. C6 yard tag unaffected by S3 work.
+  - **OTA transport:** raw `WiFiClient` + `IPAddress::fromString` for OTA fetches — bypasses `esp_http_client` / `esp-tls` / `getaddrinfo`, which on the C6 routes through OpenThread DNS64 and fails (EAI_FAIL/202) for IPv4 literals. PubSubClient uses the same WiFiClient transport. WiFi window is held across upload + OTA (was: connect → publish → disconnect → check; now: connect → publish → check → disconnect).
+  - **Validated 2026-04-25:** tag c5fffe12 OTA'd a720183 → 5423c04 end-to-end (download 1,056,480 B, sha256 verified, reboot, new fw published over MQTT, sleep 300s). Tag deployed to yard. Tasks 15b–15e (sha-mismatch / auto-rollback / low-battery skip / failed-version pin) still need bench validation.
 - **TSDB stack** (`combsense-tsdb` LXC, `deploy/tsdb/` for canonical configs)
   - Telegraf MQTT → Influx pipeline, arrival-time stamped, firmware `t` preserved as `sensor_ts` field
   - Downsample tasks: 15m cadence into `combsense_1h`, 6h cadence from `_1h` into `combsense_1d`
@@ -115,6 +118,7 @@ Read this file fully before doing anything else in this session.
 | Working on collector firmware | `firmware/collector/` directory |
 | Working on home-yard WiFi variant | `firmware/sensor-tag-wifi/` directory |
 | Sensor-tag-wifi OTA | `firmware/sensor-tag-wifi/src/ota*.cpp` + `deploy/web/publish-firmware.sh` |
+| Sensor-tag-wifi pin map / variants | `firmware/sensor-tag-wifi/include/config.h` + `platformio.ini` build_flags |
 | Shared firmware headers | `firmware/shared/` directory |
 | Making a design decision | `.mex/context/decisions.md` |
 | Writing or reviewing code | `.mex/context/conventions.md` |

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -1,7 +1,7 @@
 ---
 name: router
 description: Session bootstrap and navigation hub. Read at the start of every session before any task.
-last_updated: 2026-04-25 (sensor-tag-wifi HTTP-pull OTA happy-path validated end-to-end on c5fffe12; tag deployed to yard on 5423c04; Battery::percentFromMillivolts extracted inline + 6 native tests added on ceb0fa4; truncation contract test added → 37 native tests on 0285a16)
+last_updated: 2026-04-25 (sensor-tag-wifi HTTP-pull OTA happy-path validated end-to-end on c5fffe12; tag deployed to yard on 5423c04; Battery::percentFromMillivolts extracted inline + 6 native tests added on ceb0fa4; truncation contract test added → 37 native tests on 0285a16; payload extended with v/vbat_mV/rssi fields → 38 native tests on 7f8d628; RingBuffer MAGIC bumped 0xCB50A001→0xCB50A002 + Reading static_assert added on 31de751)
 ---
 
 ## Infrastructure
@@ -63,9 +63,10 @@ Read this file fully before doing anything else in this session.
   - Direct MQTT to local Mosquitto, RTC ring buffer for offline resilience
   - BSSID caching in RTC for fast reconnect
   - 18650 + solar powered, 5-min sample cadence by default
-  - Native Unity tests: 37 passing across payload (6), OTA manifest parser (9), OTA decision (6), OTA validate-on-boot (4), sha256 streamer (5), battery math (7)
+  - Native Unity tests: 38 passing across payload (7), OTA manifest parser (9), OTA decision (6), OTA validate-on-boot (4), sha256 streamer (5), battery math (7) — Reading static_assert guards sizeof==24
   - Epoch timestamps via NTP sync in `drainBuffer()` — persists across deep sleep via RTC; pre-sync readings emit `t=0` which Telegraf replaces with arrival time
   - NaN temperatures serialize as JSON `null` (not `nan`) so Telegraf/Swift/Postgres parsers accept them
+  - **Payload shape (7f8d628):** JSON now includes `v` (firmware version string), `vbat_mV` (raw ADC mV), `rssi` (dBm, placeholder 0 until Task 4 wires real value). `Reading` struct carries `vbat_mV uint16_t`. `Payload::serialize` signature extended with `fwVersion` and `rssi` params. `mqtt_client.cpp` passes `FIRMWARE_VERSION` macro with `"unknown"` fallback.
   - USB-CDC serial console provisioning (WiFi/MQTT/OTA creds via `tools/provision_tag.py --ota-host ...`)
   - HTTP-pull OTA on wake (manifest at `http://192.168.1.61/firmware/sensor-tag-wifi/<variant>/manifest.json`, sha256-verified, dual 1.5 MB OTA slots, bootloader auto-rollback if first publish after flash fails). Publish via `deploy/web/publish-firmware.sh <sht31|ds18b20|s3-ds18b20>`. nginx LAN-only allowlist on combsense-web LXC.
   - **Hardware variants:** Seeed XIAO ESP32-C6 (default; envs `xiao-c6-sht31`, `xiao-c6-ds18b20`) and Waveshare ESP32-S3-Zero (env `waveshare-s3zero-ds18b20`, OTA variant `s3-ds18b20`). Pin map differs (S3: OneWire→GPIO4, batt ADC→GPIO1) via build-flag overrides in `include/config.h`. S3 board flagged as `esp32-s3-devkitc-1` because `waveshare_esp32_s3_zero` is not in the pioarduino board index. C6 yard tag unaffected by S3 work.

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -1,7 +1,7 @@
 ---
 name: router
 description: Session bootstrap and navigation hub. Read at the start of every session before any task.
-last_updated: 2026-04-24 (Grafana home-yard dashboard provisioned and tracked in repo; tools/provision_tag.py committed)
+last_updated: 2026-04-24 (OTA manifest JSON parser added to sensor-tag-wifi; 5 native tests passing)
 ---
 
 ## Infrastructure
@@ -63,7 +63,7 @@ Read this file fully before doing anything else in this session.
   - Direct MQTT to local Mosquitto, RTC ring buffer for offline resilience
   - BSSID caching in RTC for fast reconnect
   - 18650 + solar powered, 5-min sample cadence by default
-  - Native Unity tests for payload serialization (6 passing, incl. t=0 case)
+  - Native Unity tests for payload serialization (6 passing, incl. t=0 case) + OTA manifest parser (5 passing)
   - Epoch timestamps via NTP sync in `drainBuffer()` — persists across deep sleep via RTC; pre-sync readings emit `t=0` which Telegraf replaces with arrival time
   - NaN temperatures serialize as JSON `null` (not `nan`) so Telegraf/Swift/Postgres parsers accept them
   - USB-CDC serial console provisioning (WiFi/MQTT creds via `tools/provision_tag.py`)

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -1,7 +1,7 @@
 ---
 name: router
 description: Session bootstrap and navigation hub. Read at the start of every session before any task.
-last_updated: 2026-04-25 (sensor-tag-wifi HTTP-pull OTA happy-path validated end-to-end on c5fffe12; tag deployed to yard on 5423c04)
+last_updated: 2026-04-25 (sensor-tag-wifi HTTP-pull OTA happy-path validated end-to-end on c5fffe12; tag deployed to yard on 5423c04; Battery::percentFromMillivolts extracted inline + 6 native tests added on ceb0fa4)
 ---
 
 ## Infrastructure
@@ -63,7 +63,7 @@ Read this file fully before doing anything else in this session.
   - Direct MQTT to local Mosquitto, RTC ring buffer for offline resilience
   - BSSID caching in RTC for fast reconnect
   - 18650 + solar powered, 5-min sample cadence by default
-  - Native Unity tests: 30 passing across payload (6), OTA manifest parser (9), OTA decision (6), OTA validate-on-boot (4), sha256 streamer (5)
+  - Native Unity tests: 36 passing across payload (6), OTA manifest parser (9), OTA decision (6), OTA validate-on-boot (4), sha256 streamer (5), battery math (6)
   - Epoch timestamps via NTP sync in `drainBuffer()` — persists across deep sleep via RTC; pre-sync readings emit `t=0` which Telegraf replaces with arrival time
   - NaN temperatures serialize as JSON `null` (not `nan`) so Telegraf/Swift/Postgres parsers accept them
   - USB-CDC serial console provisioning (WiFi/MQTT/OTA creds via `tools/provision_tag.py --ota-host ...`)

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -1,7 +1,7 @@
 ---
 name: router
 description: Session bootstrap and navigation hub. Read at the start of every session before any task.
-last_updated: 2026-04-25 (sensor-tag-wifi HTTP-pull OTA happy-path validated end-to-end on c5fffe12; tag deployed to yard on 5423c04; Battery::percentFromMillivolts extracted inline + 6 native tests added on ceb0fa4; truncation contract test added → 37 native tests on 0285a16; payload extended with v/vbat_mV/rssi fields → 38 native tests on 7f8d628; RingBuffer MAGIC bumped 0xCB50A001→0xCB50A002 + Reading static_assert added on 31de751)
+last_updated: 2026-04-25 (sensor-tag-wifi HTTP-pull OTA happy-path validated end-to-end on c5fffe12; tag deployed to yard on 5423c04; Battery::percentFromMillivolts extracted inline + 6 native tests added on ceb0fa4; truncation contract test added → 37 native tests on 0285a16; payload extended with v/vbat_mV/rssi fields → 38 native tests on 7f8d628; RingBuffer MAGIC bumped 0xCB50A001→0xCB50A002 + Reading static_assert added on 31de751; vbat_mV wired at sample time + RSSI captured post-connect and forwarded to publish on 12d8fab)
 ---
 
 ## Infrastructure
@@ -66,7 +66,8 @@ Read this file fully before doing anything else in this session.
   - Native Unity tests: 38 passing across payload (7), OTA manifest parser (9), OTA decision (6), OTA validate-on-boot (4), sha256 streamer (5), battery math (7) — Reading static_assert guards sizeof==24
   - Epoch timestamps via NTP sync in `drainBuffer()` — persists across deep sleep via RTC; pre-sync readings emit `t=0` which Telegraf replaces with arrival time
   - NaN temperatures serialize as JSON `null` (not `nan`) so Telegraf/Swift/Postgres parsers accept them
-  - **Payload shape (7f8d628):** JSON now includes `v` (firmware version string), `vbat_mV` (raw ADC mV), `rssi` (dBm, placeholder 0 until Task 4 wires real value). `Reading` struct carries `vbat_mV uint16_t`. `Payload::serialize` signature extended with `fwVersion` and `rssi` params. `mqtt_client.cpp` passes `FIRMWARE_VERSION` macro with `"unknown"` fallback.
+  - **Payload shape (7f8d628):** JSON now includes `v` (firmware version string), `vbat_mV` (raw ADC mV), `rssi` (dBm). `Reading` struct carries `vbat_mV uint16_t`. `Payload::serialize` signature extended with `fwVersion` and `rssi` params. `mqtt_client.cpp` passes `FIRMWARE_VERSION` macro with `"unknown"` fallback.
+  - **Fleet visibility wiring (12d8fab):** `sampleAndEnqueue` populates `r.vbat_mV` from `Battery::readMillivolts()` and derives `battery_pct` from the same value. `uploadAndCheckOta` captures `WiFi.RSSI()` once post-connect and forwards to every `MqttClient::publish()` call in the session. `publish()` signature now takes `int8_t rssi` (no more placeholder 0).
   - USB-CDC serial console provisioning (WiFi/MQTT/OTA creds via `tools/provision_tag.py --ota-host ...`)
   - HTTP-pull OTA on wake (manifest at `http://192.168.1.61/firmware/sensor-tag-wifi/<variant>/manifest.json`, sha256-verified, dual 1.5 MB OTA slots, bootloader auto-rollback if first publish after flash fails). Publish via `deploy/web/publish-firmware.sh <sht31|ds18b20|s3-ds18b20>`. nginx LAN-only allowlist on combsense-web LXC.
   - **Hardware variants:** Seeed XIAO ESP32-C6 (default; envs `xiao-c6-sht31`, `xiao-c6-ds18b20`) and Waveshare ESP32-S3-Zero (env `waveshare-s3zero-ds18b20`, OTA variant `s3-ds18b20`). Pin map differs (S3: OneWire→GPIO4, batt ADC→GPIO1) via build-flag overrides in `include/config.h`. S3 board flagged as `esp32-s3-devkitc-1` because `waveshare_esp32_s3_zero` is not in the pioarduino board index. C6 yard tag unaffected by S3 work.

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -1,7 +1,7 @@
 ---
 name: router
 description: Session bootstrap and navigation hub. Read at the start of every session before any task.
-last_updated: 2026-04-25 (sensor-tag-wifi HTTP-pull OTA happy-path validated end-to-end on c5fffe12; tag deployed to yard on 5423c04; Battery::percentFromMillivolts extracted inline + 6 native tests added on ceb0fa4)
+last_updated: 2026-04-25 (sensor-tag-wifi HTTP-pull OTA happy-path validated end-to-end on c5fffe12; tag deployed to yard on 5423c04; Battery::percentFromMillivolts extracted inline + 6 native tests added on ceb0fa4; truncation contract test added → 37 native tests on 0285a16)
 ---
 
 ## Infrastructure
@@ -63,7 +63,7 @@ Read this file fully before doing anything else in this session.
   - Direct MQTT to local Mosquitto, RTC ring buffer for offline resilience
   - BSSID caching in RTC for fast reconnect
   - 18650 + solar powered, 5-min sample cadence by default
-  - Native Unity tests: 36 passing across payload (6), OTA manifest parser (9), OTA decision (6), OTA validate-on-boot (4), sha256 streamer (5), battery math (6)
+  - Native Unity tests: 37 passing across payload (6), OTA manifest parser (9), OTA decision (6), OTA validate-on-boot (4), sha256 streamer (5), battery math (7)
   - Epoch timestamps via NTP sync in `drainBuffer()` — persists across deep sleep via RTC; pre-sync readings emit `t=0` which Telegraf replaces with arrival time
   - NaN temperatures serialize as JSON `null` (not `nan`) so Telegraf/Swift/Postgres parsers accept them
   - USB-CDC serial console provisioning (WiFi/MQTT/OTA creds via `tools/provision_tag.py --ota-host ...`)

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -1,7 +1,7 @@
 ---
 name: router
 description: Session bootstrap and navigation hub. Read at the start of every session before any task.
-last_updated: 2026-04-24 (OTA manifest JSON parser added to sensor-tag-wifi; 5 native tests passing)
+last_updated: 2026-04-25 (sensor-tag-wifi HTTP-pull OTA shipped — manifest+sha256 over LAN nginx; pending hardware smoke tests)
 ---
 
 ## Infrastructure
@@ -63,10 +63,11 @@ Read this file fully before doing anything else in this session.
   - Direct MQTT to local Mosquitto, RTC ring buffer for offline resilience
   - BSSID caching in RTC for fast reconnect
   - 18650 + solar powered, 5-min sample cadence by default
-  - Native Unity tests for payload serialization (6 passing, incl. t=0 case) + OTA manifest parser (5 passing)
+  - Native Unity tests: 30 passing across payload (6), OTA manifest parser (9), OTA decision (6), OTA validate-on-boot (4), sha256 streamer (5)
   - Epoch timestamps via NTP sync in `drainBuffer()` — persists across deep sleep via RTC; pre-sync readings emit `t=0` which Telegraf replaces with arrival time
   - NaN temperatures serialize as JSON `null` (not `nan`) so Telegraf/Swift/Postgres parsers accept them
-  - USB-CDC serial console provisioning (WiFi/MQTT creds via `tools/provision_tag.py`)
+  - USB-CDC serial console provisioning (WiFi/MQTT/OTA creds via `tools/provision_tag.py --ota-host ...`)
+  - HTTP-pull OTA on wake (manifest at `http://192.168.1.61/firmware/sensor-tag-wifi/<variant>/manifest.json`, sha256-verified, dual 1.5 MB OTA slots, bootloader auto-rollback if first publish after flash fails). Publish via `deploy/web/publish-firmware.sh <sht31|ds18b20>`. nginx LAN-only allowlist on combsense-web LXC.
 - **TSDB stack** (`combsense-tsdb` LXC, `deploy/tsdb/` for canonical configs)
   - Telegraf MQTT → Influx pipeline, arrival-time stamped, firmware `t` preserved as `sensor_ts` field
   - Downsample tasks: 15m cadence into `combsense_1h`, 6h cadence from `_1h` into `combsense_1d`
@@ -113,6 +114,7 @@ Read this file fully before doing anything else in this session.
 | Working on ESP32 firmware | `firmware/hive-node/` directory |
 | Working on collector firmware | `firmware/collector/` directory |
 | Working on home-yard WiFi variant | `firmware/sensor-tag-wifi/` directory |
+| Sensor-tag-wifi OTA | `firmware/sensor-tag-wifi/src/ota*.cpp` + `deploy/web/publish-firmware.sh` |
 | Shared firmware headers | `firmware/shared/` directory |
 | Making a design decision | `.mex/context/decisions.md` |
 | Writing or reviewing code | `.mex/context/conventions.md` |

--- a/deploy/tsdb/grafana/home-yard-sensors.json
+++ b/deploy/tsdb/grafana/home-yard-sensors.json
@@ -2,7 +2,7 @@
   "title": "CombSense — Home Yard Sensors",
   "uid": "combsense-home-yard",
   "schemaVersion": 39,
-  "version": 1,
+  "version": 2,
   "timezone": "",
   "refresh": "1m",
   "time": { "from": "now-24h", "to": "now" },
@@ -115,6 +115,103 @@
           "refId": "A",
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
           "query": "from(bucket: \"combsense\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"sensor_reading\" and r._field == \"t1\")\n  |> filter(fn: (r) => r.sensor_id =~ /^${sensor_id:regex}$/)\n  |> keep(columns: [\"_time\", \"_value\", \"sensor_id\"])\n  |> last()\n  |> map(fn: (r) => ({ r with _value: float(v: uint(v: r._time)) / 1000000.0 }))\n  |> group(columns: [\"sensor_id\"])"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "WiFi RSSI — per sensor",
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "dBm",
+          "max": -30,
+          "min": -100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": -85 },
+              { "color": "green", "value": -75 }
+            ]
+          },
+          "custom": { "drawStyle": "line", "lineWidth": 2, "showPoints": "never", "spanNulls": true, "thresholdsStyle": { "mode": "dashed" } }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "min", "mean"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"combsense\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"sensor_reading\" and r._field == \"rssi\")\n  |> filter(fn: (r) => r.sensor_id =~ /^${sensor_id:regex}$/)\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> keep(columns: [\"_time\", \"_value\", \"sensor_id\"])"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Battery voltage (vbat_mV) — per sensor",
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "mvolt",
+          "min": 3000,
+          "max": 4300,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 3500 },
+              { "color": "green", "value": 3700 }
+            ]
+          },
+          "custom": { "drawStyle": "line", "lineWidth": 2, "showPoints": "never", "spanNulls": true, "thresholdsStyle": { "mode": "dashed" } }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "min", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"combsense\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"sensor_reading\" and r._field == \"vbat_mV\")\n  |> filter(fn: (r) => r.sensor_id =~ /^${sensor_id:regex}$/)\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> keep(columns: [\"_time\", \"_value\", \"sensor_id\"])"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Firmware version — per sensor",
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 26 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "blue" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"combsense\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"sensor_reading\" and r._field == \"fw_version\")\n  |> filter(fn: (r) => r.sensor_id =~ /^${sensor_id:regex}$/)\n  |> keep(columns: [\"_time\", \"_value\", \"sensor_id\"])\n  |> last()\n  |> group(columns: [\"sensor_id\"])"
         }
       ]
     }

--- a/deploy/tsdb/telegraf-combsense.conf
+++ b/deploy/tsdb/telegraf-combsense.conf
@@ -33,6 +33,19 @@
       rename = "sensor_ts"
       type = "int"
       optional = true
+    [[inputs.mqtt_consumer.json_v2.field]]
+      path = "v"
+      rename = "fw_version"
+      type = "string"
+      optional = true
+    [[inputs.mqtt_consumer.json_v2.field]]
+      path = "vbat_mV"
+      type = "int"
+      optional = true
+    [[inputs.mqtt_consumer.json_v2.field]]
+      path = "rssi"
+      type = "int"
+      optional = true
 
 [[outputs.influxdb_v2]]
   urls = ["http://127.0.0.1:8086"]

--- a/deploy/web/nginx/combsense-web.conf
+++ b/deploy/web/nginx/combsense-web.conf
@@ -1,14 +1,26 @@
 # /etc/nginx/sites-available/combsense-web
 # Day 1: self-signed, LAN-only.  Phase 2: swap cert paths + uncomment HSTS.
 
-# --- HTTP (:80) — ACME challenge passthrough; everything else → HTTPS
+# --- HTTP (:80) — ACME challenge passthrough; firmware on LAN; rest → HTTPS
 server {
     listen 80;
     listen [::]:80;
-    server_name dashboard.combsense.com;
+    server_name dashboard.combsense.com 192.168.1.61;
 
     location /.well-known/acme-challenge/ {
         root /var/www/html;
+    }
+
+    # LAN-only firmware OTA pull. Integrity is sha256 in the manifest;
+    # the allow/deny block prevents accidental WAN exposure.
+    location /firmware/ {
+        alias /var/www/combsense-firmware/;
+        autoindex off;
+        default_type application/octet-stream;
+        types { application/json json; application/octet-stream bin; }
+
+        allow 192.168.0.0/16;
+        deny all;
     }
 
     location / {

--- a/deploy/web/publish-firmware.sh
+++ b/deploy/web/publish-firmware.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Build sensor-tag-wifi firmware for <variant>, upload to the OTA host, and
+# publish a fresh manifest. Run from the repo root.
+#
+# Usage:  deploy/web/publish-firmware.sh <sht31|ds18b20>
+
+set -euo pipefail
+
+VARIANT="${1:-}"
+if [[ "$VARIANT" != "sht31" && "$VARIANT" != "ds18b20" ]]; then
+    echo "usage: $0 <sht31|ds18b20>" >&2
+    exit 2
+fi
+
+OTA_HOST="${OTA_HOST:-192.168.1.61}"
+OTA_USER="${OTA_USER:-natas}"
+OTA_ROOT="/var/www/combsense-firmware/sensor-tag-wifi/${VARIANT}"
+WEB_BASE="http://${OTA_HOST}/firmware/sensor-tag-wifi/${VARIANT}"
+
+cd firmware/sensor-tag-wifi
+
+VERSION="$(git describe --tags --always)"
+echo "[publish] variant=${VARIANT} version=${VERSION}"
+
+pio run -e "xiao-c6-${VARIANT}"
+BIN=".pio/build/xiao-c6-${VARIANT}/firmware.bin"
+[[ -f "$BIN" ]] || { echo "build did not produce ${BIN}" >&2; exit 1; }
+
+SHA="$(shasum -a 256 "$BIN" | awk '{print $1}')"
+SIZE="$(stat -f '%z' "$BIN" 2>/dev/null || stat -c '%s' "$BIN")"
+echo "[publish] sha256=${SHA} size=${SIZE}"
+
+MANIFEST=$(mktemp)
+cat > "$MANIFEST" <<EOF
+{
+  "version": "${VERSION}",
+  "url": "${WEB_BASE}/${VERSION}/firmware.bin",
+  "sha256": "${SHA}",
+  "size": ${SIZE}
+}
+EOF
+
+scp "$BIN" "${OTA_USER}@${OTA_HOST}:/tmp/firmware.bin"
+scp "$MANIFEST" "${OTA_USER}@${OTA_HOST}:/tmp/manifest.json"
+rm -f "$MANIFEST"
+
+ssh "${OTA_USER}@${OTA_HOST}" sudo bash -s <<EOF
+set -euo pipefail
+mkdir -p "${OTA_ROOT}/${VERSION}"
+mv /tmp/firmware.bin "${OTA_ROOT}/${VERSION}/firmware.bin"
+chmod 644 "${OTA_ROOT}/${VERSION}/firmware.bin"
+mv /tmp/manifest.json "${OTA_ROOT}/manifest.json"
+chmod 644 "${OTA_ROOT}/manifest.json"
+EOF
+
+echo "[publish] done — manifest at ${WEB_BASE}/manifest.json"

--- a/deploy/web/publish-firmware.sh
+++ b/deploy/web/publish-firmware.sh
@@ -2,15 +2,20 @@
 # Build sensor-tag-wifi firmware for <variant>, upload to the OTA host, and
 # publish a fresh manifest. Run from the repo root.
 #
-# Usage:  deploy/web/publish-firmware.sh <sht31|ds18b20>
+# Usage:  deploy/web/publish-firmware.sh <sht31|ds18b20|s3-ds18b20>
 
 set -euo pipefail
 
 VARIANT="${1:-}"
-if [[ "$VARIANT" != "sht31" && "$VARIANT" != "ds18b20" ]]; then
-    echo "usage: $0 <sht31|ds18b20>" >&2
-    exit 2
-fi
+
+# Map variant token → PlatformIO env name.
+# The variant token drives the OTA URL path; the env name drives the build.
+case "$VARIANT" in
+    sht31)      ENV="xiao-c6-sht31" ;;
+    ds18b20)    ENV="xiao-c6-ds18b20" ;;
+    s3-ds18b20) ENV="waveshare-s3zero-ds18b20" ;;
+    *) echo "usage: $0 <sht31|ds18b20|s3-ds18b20>" >&2; exit 2 ;;
+esac
 
 OTA_HOST="${OTA_HOST:-192.168.1.61}"
 OTA_USER="${OTA_USER:-natas}"
@@ -20,10 +25,10 @@ WEB_BASE="http://${OTA_HOST}/firmware/sensor-tag-wifi/${VARIANT}"
 cd firmware/sensor-tag-wifi
 
 VERSION="$(git describe --tags --always)"
-echo "[publish] variant=${VARIANT} version=${VERSION}"
+echo "[publish] variant=${VARIANT} env=${ENV} version=${VERSION}"
 
-pio run -e "xiao-c6-${VARIANT}"
-BIN=".pio/build/xiao-c6-${VARIANT}/firmware.bin"
+pio run -e "$ENV"
+BIN=".pio/build/$ENV/firmware.bin"
 [[ -f "$BIN" ]] || { echo "build did not produce ${BIN}" >&2; exit 1; }
 
 SHA="$(shasum -a 256 "$BIN" | awk '{print $1}')"

--- a/docs/superpowers/plans/2026-04-24-sensor-tag-wifi-ota.md
+++ b/docs/superpowers/plans/2026-04-24-sensor-tag-wifi-ota.md
@@ -1,0 +1,1882 @@
+# Sensor-Tag-Wifi OTA Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the home-yard `sensor-tag-wifi` (XIAO ESP32-C6) HTTP-pull OTA so a device deployed at a beehive can be updated without physical access.
+
+**Architecture:** Per-wake flow — after publishing the reading, fetch a JSON manifest from a local nginx host, compare to compiled-in `FIRMWARE_VERSION`, stream-download the binary into the inactive OTA slot with running SHA-256, verify, set boot partition, and reboot. New firmware proves itself by completing one publish; otherwise the bootloader rolls back. All decision logic lives in pure functions with native Unity tests.
+
+**Tech Stack:**
+- Firmware: ESP-IDF `esp_ota_*` + `esp_http_client_*`, Arduino `Preferences`, mbedtls SHA-256
+- Build: PlatformIO `pioarduino` (53.03.10), `extra_scripts = pre:get_version.py`
+- Tests: Unity native (`pio test -e native`), `picosha2.h` for native SHA-256
+- Server: nginx fragment on `combsense-web` LXC (192.168.1.61), bash publish script
+- Provisioning: extension to existing `serial_console` + `tools/provision_tag.py`
+
+**Spec:** `docs/superpowers/specs/2026-04-24-sensor-tag-wifi-ota-design.md` (committed at `399db5e`).
+
+---
+
+## File Structure
+
+### New firmware files
+- `firmware/sensor-tag-wifi/include/ota.h` — public `Ota::` API
+- `firmware/sensor-tag-wifi/src/ota.cpp` — side-effecting shell (HTTP + `esp_ota_*`)
+- `firmware/sensor-tag-wifi/include/ota_manifest.h` — `Manifest` struct + parser declaration
+- `firmware/sensor-tag-wifi/src/ota_manifest.cpp` — pure JSON parser
+- `firmware/sensor-tag-wifi/include/ota_decision.h` — pure decision functions
+- `firmware/sensor-tag-wifi/src/ota_decision.cpp` — pure decision functions
+- `firmware/sensor-tag-wifi/include/ota_state.h` — Preferences adapter interface
+- `firmware/sensor-tag-wifi/src/ota_state.cpp` — Preferences adapter (device + native shim)
+- `firmware/sensor-tag-wifi/include/ota_sha256.h` — streaming SHA-256 wrapper
+- `firmware/sensor-tag-wifi/src/ota_sha256.cpp` — mbedtls (device) / picosha2 (native) backend
+- `firmware/sensor-tag-wifi/include/picosha2.h` — vendored single-header SHA-256 (MIT)
+- `firmware/sensor-tag-wifi/get_version.py` — PIO pre-script
+
+### New test files (each in its own dir per PIO Unity convention)
+- `firmware/sensor-tag-wifi/test/test_ota_manifest/test_ota_manifest.cpp`
+- `firmware/sensor-tag-wifi/test/test_ota_decision/test_ota_decision.cpp`
+- `firmware/sensor-tag-wifi/test/test_ota_validation/test_ota_validation.cpp`
+- `firmware/sensor-tag-wifi/test/test_ota_sha256/test_ota_sha256.cpp`
+
+### Modified firmware files
+- `firmware/sensor-tag-wifi/include/config.h` — add OTA constants
+- `firmware/sensor-tag-wifi/partitions_tag.csv` — single 3 MB app → dual 1.5 MB OTA slots
+- `firmware/sensor-tag-wifi/platformio.ini` — `extra_scripts`, `OTA_VARIANT`, native `build_src_filter`
+- `firmware/sensor-tag-wifi/src/main.cpp` — wire `Ota::validateOnBoot` / `onPublishSuccess` / `checkAndApply`
+- `firmware/sensor-tag-wifi/src/serial_console.cpp` — add `ota_host` to known keys
+
+### New / modified deploy + tooling files
+- `deploy/web/nginx/combsense-web.conf` — add `/firmware/` location (HTTP `:80`)
+- `deploy/web/publish-firmware.sh` — new build+upload+manifest script
+- `tools/provision_tag.py` — `--ota-host` flag
+
+---
+
+## Task ordering rationale
+
+1. **Tasks 1–4**: pure-function modules first, fully native-testable. Each is a complete TDD cycle.
+2. **Task 5**: build system wiring (version + variant + native env additions). Required before any device build.
+3. **Task 6**: dual-slot partition table.
+4. **Tasks 7–8**: side-effecting shell layered on top of the pure functions.
+5. **Task 9**: integrate into `main.cpp`. Device build must succeed end-to-end here.
+6. **Tasks 10–11**: provisioning ergonomics for `ota_host`.
+7. **Tasks 12–13**: server side (LXC nginx + publish script). Independent of firmware tasks; can be done in parallel by an operator but plan keeps them sequential for review simplicity.
+8. **Tasks 14–15**: bootstrap + hardware smoke tests.
+
+---
+
+## Task 1: ota_manifest — pure JSON parser
+
+**Files:**
+- Create: `firmware/sensor-tag-wifi/include/ota_manifest.h`
+- Create: `firmware/sensor-tag-wifi/src/ota_manifest.cpp`
+- Create: `firmware/sensor-tag-wifi/test/test_ota_manifest/test_ota_manifest.cpp`
+- Modify: `firmware/sensor-tag-wifi/platformio.ini` (native env `build_src_filter`)
+
+- [ ] **Step 1: Write the header**
+
+`firmware/sensor-tag-wifi/include/ota_manifest.h`:
+```cpp
+#pragma once
+
+#include <cstddef>
+
+struct Manifest {
+    char version[32];
+    char url[256];
+    char sha256[65];   // 64 hex chars + null
+    size_t size;
+};
+
+bool parseManifest(const char* json, size_t len, Manifest& out);
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`firmware/sensor-tag-wifi/test/test_ota_manifest/test_ota_manifest.cpp`:
+```cpp
+#include <unity.h>
+#include <cstring>
+#include "ota_manifest.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_parses_valid_manifest() {
+    const char* j =
+        "{\"version\":\"v0.2.0\","
+        "\"url\":\"http://192.168.1.61/firmware/sensor-tag-wifi/sht31/v0.2.0/firmware.bin\","
+        "\"sha256\":\"abc123def456abc123def456abc123def456abc123def456abc123def4561234\","
+        "\"size\":1046912}";
+    Manifest m {};
+    TEST_ASSERT_TRUE(parseManifest(j, strlen(j), m));
+    TEST_ASSERT_EQUAL_STRING("v0.2.0", m.version);
+    TEST_ASSERT_EQUAL_STRING(
+        "http://192.168.1.61/firmware/sensor-tag-wifi/sht31/v0.2.0/firmware.bin", m.url);
+    TEST_ASSERT_EQUAL_STRING(
+        "abc123def456abc123def456abc123def456abc123def456abc123def4561234", m.sha256);
+    TEST_ASSERT_EQUAL_UINT32(1046912, m.size);
+}
+
+void test_rejects_missing_field() {
+    const char* j = "{\"version\":\"v0.2.0\",\"url\":\"http://x/y\",\"size\":100}";
+    Manifest m {};
+    TEST_ASSERT_FALSE(parseManifest(j, strlen(j), m));
+}
+
+void test_rejects_malformed_json() {
+    const char* j = "{not valid json";
+    Manifest m {};
+    TEST_ASSERT_FALSE(parseManifest(j, strlen(j), m));
+}
+
+void test_rejects_oversize_url() {
+    char j[600];
+    char url[300];
+    memset(url, 'a', sizeof(url) - 1);
+    url[sizeof(url) - 1] = '\0';
+    snprintf(j, sizeof(j),
+        "{\"version\":\"v1\",\"url\":\"%s\",\"sha256\":\"%s\",\"size\":1}",
+        url,
+        "0000000000000000000000000000000000000000000000000000000000000000");
+    Manifest m {};
+    TEST_ASSERT_FALSE(parseManifest(j, strlen(j), m));
+}
+
+void test_rejects_wrong_sha_length() {
+    const char* j =
+        "{\"version\":\"v1\",\"url\":\"http://x/y\","
+        "\"sha256\":\"deadbeef\",\"size\":1}";
+    Manifest m {};
+    TEST_ASSERT_FALSE(parseManifest(j, strlen(j), m));
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_parses_valid_manifest);
+    RUN_TEST(test_rejects_missing_field);
+    RUN_TEST(test_rejects_malformed_json);
+    RUN_TEST(test_rejects_oversize_url);
+    RUN_TEST(test_rejects_wrong_sha_length);
+    return UNITY_END();
+}
+```
+
+- [ ] **Step 3: Add ota_manifest.cpp to native build_src_filter**
+
+Edit `firmware/sensor-tag-wifi/platformio.ini`, replace the `[env:native]` block's `build_src_filter` with:
+```ini
+build_src_filter =
+    +<payload.cpp>
+    +<ota_manifest.cpp>
+```
+
+- [ ] **Step 4: Run the test, verify it fails**
+
+```bash
+cd firmware/sensor-tag-wifi
+pio test -e native -f test_ota_manifest
+```
+
+Expected: FAIL — link error (`parseManifest` undefined) or compile error.
+
+- [ ] **Step 5: Write the minimal implementation**
+
+`firmware/sensor-tag-wifi/src/ota_manifest.cpp`:
+```cpp
+#include "ota_manifest.h"
+
+#include <cstring>
+#include <cstdlib>
+#include <cctype>
+
+namespace {
+
+const char* findKey(const char* json, size_t len, const char* key) {
+    char needle[40];
+    int n = snprintf(needle, sizeof(needle), "\"%s\"", key);
+    if (n <= 0 || (size_t)n >= sizeof(needle)) return nullptr;
+    const char* end = json + len;
+    for (const char* p = json; p + n <= end; p++) {
+        if (memcmp(p, needle, n) == 0) return p + n;
+    }
+    return nullptr;
+}
+
+bool extractString(const char* json, size_t len, const char* key,
+                   char* out, size_t outCap) {
+    const char* p = findKey(json, len, key);
+    if (!p) return false;
+    const char* end = json + len;
+    while (p < end && *p != ':') p++;
+    if (p == end) return false;
+    p++;
+    while (p < end && isspace((unsigned char)*p)) p++;
+    if (p == end || *p != '"') return false;
+    p++;
+    const char* start = p;
+    while (p < end && *p != '"') p++;
+    if (p == end) return false;
+    size_t length = (size_t)(p - start);
+    if (length + 1 > outCap) return false;
+    memcpy(out, start, length);
+    out[length] = '\0';
+    return true;
+}
+
+bool extractNumber(const char* json, size_t len, const char* key, size_t& out) {
+    const char* p = findKey(json, len, key);
+    if (!p) return false;
+    const char* end = json + len;
+    while (p < end && *p != ':') p++;
+    if (p == end) return false;
+    p++;
+    while (p < end && isspace((unsigned char)*p)) p++;
+    if (p == end || !isdigit((unsigned char)*p)) return false;
+    char buf[24] = {};
+    size_t i = 0;
+    while (p < end && isdigit((unsigned char)*p) && i < sizeof(buf) - 1) {
+        buf[i++] = *p++;
+    }
+    out = (size_t)strtoul(buf, nullptr, 10);
+    return true;
+}
+
+}  // namespace
+
+bool parseManifest(const char* json, size_t len, Manifest& out) {
+    if (!json || len == 0) return false;
+    if (!extractString(json, len, "version", out.version, sizeof(out.version))) return false;
+    if (!extractString(json, len, "url",     out.url,     sizeof(out.url)))     return false;
+    if (!extractString(json, len, "sha256",  out.sha256,  sizeof(out.sha256)))  return false;
+    if (strlen(out.sha256) != 64) return false;
+    if (!extractNumber(json, len, "size", out.size)) return false;
+    return true;
+}
+```
+
+- [ ] **Step 6: Run the tests, verify they pass**
+
+```bash
+cd firmware/sensor-tag-wifi
+pio test -e native -f test_ota_manifest
+```
+
+Expected: PASS — 5 tests passing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add firmware/sensor-tag-wifi/include/ota_manifest.h \
+        firmware/sensor-tag-wifi/src/ota_manifest.cpp \
+        firmware/sensor-tag-wifi/test/test_ota_manifest/test_ota_manifest.cpp \
+        firmware/sensor-tag-wifi/platformio.ini
+git commit -m "feat(sensor-tag-wifi): manifest JSON parser with native tests"
+```
+
+---
+
+## Task 2: ota_decision — pure decision functions
+
+**Files:**
+- Create: `firmware/sensor-tag-wifi/include/ota_decision.h`
+- Create: `firmware/sensor-tag-wifi/src/ota_decision.cpp`
+- Create: `firmware/sensor-tag-wifi/test/test_ota_decision/test_ota_decision.cpp`
+- Create: `firmware/sensor-tag-wifi/test/test_ota_validation/test_ota_validation.cpp`
+- Modify: `firmware/sensor-tag-wifi/platformio.ini` (native `build_src_filter`)
+
+- [ ] **Step 1: Write the header**
+
+`firmware/sensor-tag-wifi/include/ota_decision.h`:
+```cpp
+#pragma once
+
+#include <cstdint>
+
+bool shouldApply(const char* current,
+                 const char* manifest,
+                 const char* failed,
+                 uint8_t batteryPct);
+
+enum class ValidateAction {
+    NoOp,
+    ClearAttempted,
+    RecordFailed,
+};
+
+ValidateAction validateOnBootAction(const char* firmwareVersion,
+                                    const char* attempted,
+                                    bool isPendingVerify);
+```
+
+- [ ] **Step 2: Write the failing tests for shouldApply**
+
+`firmware/sensor-tag-wifi/test/test_ota_decision/test_ota_decision.cpp`:
+```cpp
+#include <unity.h>
+#include "ota_decision.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_skip_when_versions_match() {
+    TEST_ASSERT_FALSE(shouldApply("v0.2.0", "v0.2.0", "", 100));
+}
+
+void test_skip_when_manifest_matches_failed() {
+    TEST_ASSERT_FALSE(shouldApply("v0.2.0", "v0.3.0", "v0.3.0", 100));
+}
+
+void test_skip_when_battery_below_floor() {
+    TEST_ASSERT_FALSE(shouldApply("v0.2.0", "v0.3.0", "", 19));
+}
+
+void test_apply_when_new_version_and_healthy_battery() {
+    TEST_ASSERT_TRUE(shouldApply("v0.2.0", "v0.3.0", "", 20));
+    TEST_ASSERT_TRUE(shouldApply("v0.2.0", "v0.3.0", "", 100));
+}
+
+void test_apply_when_failed_is_different_version() {
+    TEST_ASSERT_TRUE(shouldApply("v0.2.0", "v0.3.0", "v0.2.5", 80));
+}
+
+void test_skip_when_manifest_empty() {
+    TEST_ASSERT_FALSE(shouldApply("v0.2.0", "", "", 100));
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_skip_when_versions_match);
+    RUN_TEST(test_skip_when_manifest_matches_failed);
+    RUN_TEST(test_skip_when_battery_below_floor);
+    RUN_TEST(test_apply_when_new_version_and_healthy_battery);
+    RUN_TEST(test_apply_when_failed_is_different_version);
+    RUN_TEST(test_skip_when_manifest_empty);
+    return UNITY_END();
+}
+```
+
+- [ ] **Step 3: Write the failing tests for validateOnBootAction**
+
+`firmware/sensor-tag-wifi/test/test_ota_validation/test_ota_validation.cpp`:
+```cpp
+#include <unity.h>
+#include "ota_decision.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_noop_when_attempted_empty() {
+    TEST_ASSERT_TRUE(validateOnBootAction("v0.2.0", "", false) == ValidateAction::NoOp);
+    TEST_ASSERT_TRUE(validateOnBootAction("v0.2.0", "", true)  == ValidateAction::NoOp);
+}
+
+void test_noop_when_pending_and_versions_match() {
+    TEST_ASSERT_TRUE(
+        validateOnBootAction("v0.3.0", "v0.3.0", true) == ValidateAction::NoOp);
+}
+
+void test_clear_attempted_when_already_validated() {
+    TEST_ASSERT_TRUE(
+        validateOnBootAction("v0.3.0", "v0.3.0", false) == ValidateAction::ClearAttempted);
+}
+
+void test_record_failed_when_running_old_firmware_after_attempt() {
+    TEST_ASSERT_TRUE(
+        validateOnBootAction("v0.2.0", "v0.3.0", false) == ValidateAction::RecordFailed);
+    TEST_ASSERT_TRUE(
+        validateOnBootAction("v0.2.0", "v0.3.0", true)  == ValidateAction::RecordFailed);
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_noop_when_attempted_empty);
+    RUN_TEST(test_noop_when_pending_and_versions_match);
+    RUN_TEST(test_clear_attempted_when_already_validated);
+    RUN_TEST(test_record_failed_when_running_old_firmware_after_attempt);
+    return UNITY_END();
+}
+```
+
+- [ ] **Step 4: Add ota_decision.cpp to native build_src_filter**
+
+Edit `[env:native]` `build_src_filter` to:
+```ini
+build_src_filter =
+    +<payload.cpp>
+    +<ota_manifest.cpp>
+    +<ota_decision.cpp>
+```
+
+- [ ] **Step 5: Run tests, verify they fail**
+
+```bash
+cd firmware/sensor-tag-wifi
+pio test -e native -f test_ota_decision -f test_ota_validation
+```
+
+Expected: FAIL — link errors.
+
+- [ ] **Step 6: Write the implementation**
+
+`firmware/sensor-tag-wifi/src/ota_decision.cpp`:
+```cpp
+#include "ota_decision.h"
+
+#include <cstring>
+
+namespace {
+constexpr uint8_t BATTERY_FLOOR_PCT = 20;
+
+bool isEmpty(const char* s) { return s == nullptr || s[0] == '\0'; }
+}  // namespace
+
+bool shouldApply(const char* current,
+                 const char* manifest,
+                 const char* failed,
+                 uint8_t batteryPct) {
+    if (isEmpty(manifest)) return false;
+    if (!isEmpty(current) && strcmp(current, manifest) == 0) return false;
+    if (!isEmpty(failed) && strcmp(failed, manifest) == 0) return false;
+    if (batteryPct < BATTERY_FLOOR_PCT) return false;
+    return true;
+}
+
+ValidateAction validateOnBootAction(const char* firmwareVersion,
+                                    const char* attempted,
+                                    bool isPendingVerify) {
+    if (isEmpty(attempted)) return ValidateAction::NoOp;
+    if (strcmp(firmwareVersion, attempted) == 0) {
+        return isPendingVerify ? ValidateAction::NoOp : ValidateAction::ClearAttempted;
+    }
+    return ValidateAction::RecordFailed;
+}
+```
+
+- [ ] **Step 7: Run tests, verify they pass**
+
+```bash
+cd firmware/sensor-tag-wifi
+pio test -e native -f test_ota_decision -f test_ota_validation
+```
+
+Expected: PASS — 6 + 4 = 10 tests passing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add firmware/sensor-tag-wifi/include/ota_decision.h \
+        firmware/sensor-tag-wifi/src/ota_decision.cpp \
+        firmware/sensor-tag-wifi/test/test_ota_decision/test_ota_decision.cpp \
+        firmware/sensor-tag-wifi/test/test_ota_validation/test_ota_validation.cpp \
+        firmware/sensor-tag-wifi/platformio.ini
+git commit -m "feat(sensor-tag-wifi): pure OTA decision + boot-validation logic"
+```
+
+---
+
+## Task 3: ota_sha256 — streaming SHA-256 verifier
+
+**Files:**
+- Create: `firmware/sensor-tag-wifi/include/picosha2.h` (vendored)
+- Create: `firmware/sensor-tag-wifi/include/ota_sha256.h`
+- Create: `firmware/sensor-tag-wifi/src/ota_sha256.cpp`
+- Create: `firmware/sensor-tag-wifi/test/test_ota_sha256/test_ota_sha256.cpp`
+- Modify: `firmware/sensor-tag-wifi/platformio.ini`
+
+- [ ] **Step 1: Vendor picosha2.h**
+
+Download `https://raw.githubusercontent.com/okdshin/PicoSHA2/27fcf6979298949e8a462e16d09a0351c18fcaf2/picosha2.h` and save it as `firmware/sensor-tag-wifi/include/picosha2.h`. Single-header SHA-256, MIT license — used only when building for `native` (mbedtls is unavailable off-target).
+
+```bash
+curl -fsSL "https://raw.githubusercontent.com/okdshin/PicoSHA2/27fcf6979298949e8a462e16d09a0351c18fcaf2/picosha2.h" \
+    -o firmware/sensor-tag-wifi/include/picosha2.h
+```
+
+Verify the file is ~140 lines and starts with the `#ifndef PICOSHA2_H` guard.
+
+- [ ] **Step 2: Write the header**
+
+`firmware/sensor-tag-wifi/include/ota_sha256.h`:
+```cpp
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+class Sha256Streamer {
+public:
+    Sha256Streamer();
+    ~Sha256Streamer();
+
+    void reset();
+    void update(const uint8_t* data, size_t len);
+    void finalizeToHex(char outHex[65]);   // writes 64 lowercase hex + null
+
+    bool matches(const char* expectedHex);  // resets internally; call after finalizeToHex
+
+private:
+    void* impl_;
+    char lastHex_[65];
+};
+```
+
+- [ ] **Step 3: Write the failing test**
+
+`firmware/sensor-tag-wifi/test/test_ota_sha256/test_ota_sha256.cpp`:
+```cpp
+#include <unity.h>
+#include <cstring>
+#include "ota_sha256.h"
+
+void setUp() {}
+void tearDown() {}
+
+// Known SHA-256 fixtures
+// "" -> e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+// "abc" -> ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+
+void test_empty_input_hash() {
+    Sha256Streamer s;
+    char hex[65] = {};
+    s.finalizeToHex(hex);
+    TEST_ASSERT_EQUAL_STRING(
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hex);
+}
+
+void test_single_chunk_abc() {
+    Sha256Streamer s;
+    s.update(reinterpret_cast<const uint8_t*>("abc"), 3);
+    char hex[65] = {};
+    s.finalizeToHex(hex);
+    TEST_ASSERT_EQUAL_STRING(
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", hex);
+}
+
+void test_streaming_matches_single_chunk() {
+    Sha256Streamer s;
+    s.update(reinterpret_cast<const uint8_t*>("a"), 1);
+    s.update(reinterpret_cast<const uint8_t*>("b"), 1);
+    s.update(reinterpret_cast<const uint8_t*>("c"), 1);
+    char hex[65] = {};
+    s.finalizeToHex(hex);
+    TEST_ASSERT_EQUAL_STRING(
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", hex);
+}
+
+void test_matches_compares_case_insensitive() {
+    Sha256Streamer s;
+    s.update(reinterpret_cast<const uint8_t*>("abc"), 3);
+    char hex[65] = {};
+    s.finalizeToHex(hex);
+    TEST_ASSERT_TRUE(s.matches(
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"));
+    TEST_ASSERT_TRUE(s.matches(
+        "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD"));
+    TEST_ASSERT_FALSE(s.matches("0000000000000000000000000000000000000000000000000000000000000000"));
+}
+
+void test_reset_allows_reuse() {
+    Sha256Streamer s;
+    s.update(reinterpret_cast<const uint8_t*>("ignored"), 7);
+    s.reset();
+    s.update(reinterpret_cast<const uint8_t*>("abc"), 3);
+    char hex[65] = {};
+    s.finalizeToHex(hex);
+    TEST_ASSERT_EQUAL_STRING(
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", hex);
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_empty_input_hash);
+    RUN_TEST(test_single_chunk_abc);
+    RUN_TEST(test_streaming_matches_single_chunk);
+    RUN_TEST(test_matches_compares_case_insensitive);
+    RUN_TEST(test_reset_allows_reuse);
+    return UNITY_END();
+}
+```
+
+- [ ] **Step 4: Add ota_sha256.cpp to native build_src_filter**
+
+Edit `[env:native]` `build_src_filter` to:
+```ini
+build_src_filter =
+    +<payload.cpp>
+    +<ota_manifest.cpp>
+    +<ota_decision.cpp>
+    +<ota_sha256.cpp>
+```
+
+- [ ] **Step 5: Run, verify failure**
+
+```bash
+cd firmware/sensor-tag-wifi
+pio test -e native -f test_ota_sha256
+```
+
+Expected: FAIL — link error.
+
+- [ ] **Step 6: Write the implementation**
+
+`firmware/sensor-tag-wifi/src/ota_sha256.cpp`:
+```cpp
+#include "ota_sha256.h"
+
+#include <cstring>
+#include <cctype>
+
+#ifdef ESP_PLATFORM
+#include "mbedtls/sha256.h"
+struct Backend {
+    mbedtls_sha256_context ctx;
+    Backend() { mbedtls_sha256_init(&ctx); mbedtls_sha256_starts(&ctx, 0); }
+    ~Backend() { mbedtls_sha256_free(&ctx); }
+    void reset() {
+        mbedtls_sha256_free(&ctx);
+        mbedtls_sha256_init(&ctx);
+        mbedtls_sha256_starts(&ctx, 0);
+    }
+    void update(const uint8_t* d, size_t n) { mbedtls_sha256_update(&ctx, d, n); }
+    void finalize(uint8_t out[32]) { mbedtls_sha256_finish(&ctx, out); }
+};
+#else
+#include "picosha2.h"
+struct Backend {
+    picosha2::hash256_one_by_one hasher;
+    Backend() { hasher.init(); }
+    void reset() { hasher.init(); }
+    void update(const uint8_t* d, size_t n) { hasher.process(d, d + n); }
+    void finalize(uint8_t out[32]) {
+        hasher.finish();
+        std::vector<unsigned char> v;
+        hasher.get_hash_bytes(v);
+        memcpy(out, v.data(), 32);
+    }
+};
+#endif
+
+namespace {
+void toHex(const uint8_t in[32], char out[65]) {
+    static const char* lut = "0123456789abcdef";
+    for (size_t i = 0; i < 32; i++) {
+        out[2 * i]     = lut[in[i] >> 4];
+        out[2 * i + 1] = lut[in[i] & 0x0f];
+    }
+    out[64] = '\0';
+}
+
+bool hexEqIgnoreCase(const char* a, const char* b) {
+    while (*a && *b) {
+        if (tolower((unsigned char)*a) != tolower((unsigned char)*b)) return false;
+        a++; b++;
+    }
+    return *a == '\0' && *b == '\0';
+}
+}  // namespace
+
+Sha256Streamer::Sha256Streamer() : impl_(new Backend()) { lastHex_[0] = '\0'; }
+Sha256Streamer::~Sha256Streamer() { delete static_cast<Backend*>(impl_); }
+
+void Sha256Streamer::reset() { static_cast<Backend*>(impl_)->reset(); lastHex_[0] = '\0'; }
+void Sha256Streamer::update(const uint8_t* data, size_t len) {
+    static_cast<Backend*>(impl_)->update(data, len);
+}
+void Sha256Streamer::finalizeToHex(char outHex[65]) {
+    uint8_t raw[32];
+    static_cast<Backend*>(impl_)->finalize(raw);
+    toHex(raw, outHex);
+    memcpy(lastHex_, outHex, 65);
+}
+bool Sha256Streamer::matches(const char* expectedHex) {
+    if (lastHex_[0] == '\0') return false;
+    return hexEqIgnoreCase(lastHex_, expectedHex);
+}
+```
+
+- [ ] **Step 7: Run tests, verify they pass**
+
+```bash
+cd firmware/sensor-tag-wifi
+pio test -e native -f test_ota_sha256
+```
+
+Expected: PASS — 5 tests passing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add firmware/sensor-tag-wifi/include/picosha2.h \
+        firmware/sensor-tag-wifi/include/ota_sha256.h \
+        firmware/sensor-tag-wifi/src/ota_sha256.cpp \
+        firmware/sensor-tag-wifi/test/test_ota_sha256/test_ota_sha256.cpp \
+        firmware/sensor-tag-wifi/platformio.ini
+git commit -m "feat(sensor-tag-wifi): streaming SHA-256 verifier (mbedtls/picosha2)"
+```
+
+---
+
+## Task 4: ota_state — Preferences adapter
+
+**Files:**
+- Create: `firmware/sensor-tag-wifi/include/ota_state.h`
+- Create: `firmware/sensor-tag-wifi/src/ota_state.cpp`
+
+This file is **device-only** (uses Arduino `Preferences`), so no native test. The decision logic is already covered by `test_ota_decision`/`test_ota_validation`.
+
+- [ ] **Step 1: Write the header**
+
+`firmware/sensor-tag-wifi/include/ota_state.h`:
+```cpp
+#pragma once
+
+namespace OtaState {
+    void getAttempted(char* out, size_t outCap);
+    void setAttempted(const char* version);
+    void clearAttempted();
+
+    void getFailed(char* out, size_t outCap);
+    void setFailed(const char* version);
+    void clearFailed();
+}
+```
+
+- [ ] **Step 2: Write the implementation**
+
+`firmware/sensor-tag-wifi/src/ota_state.cpp`:
+```cpp
+#include "ota_state.h"
+
+#include <Preferences.h>
+#include <cstring>
+
+namespace {
+constexpr const char* OTA_NS  = "ota";
+constexpr const char* K_ATTEMPTED = "attempted";
+constexpr const char* K_FAILED    = "failed";
+
+void readKey(const char* key, char* out, size_t outCap) {
+    Preferences p;
+    p.begin(OTA_NS, true);
+    String v = p.getString(key, "");
+    p.end();
+    size_t n = v.length() < outCap ? v.length() : outCap - 1;
+    memcpy(out, v.c_str(), n);
+    out[n] = '\0';
+}
+
+void writeKey(const char* key, const char* value) {
+    Preferences p;
+    p.begin(OTA_NS, false);
+    p.putString(key, value);
+    p.end();
+}
+
+void removeKey(const char* key) {
+    Preferences p;
+    p.begin(OTA_NS, false);
+    p.remove(key);
+    p.end();
+}
+}  // namespace
+
+namespace OtaState {
+
+void getAttempted(char* out, size_t outCap) { readKey(K_ATTEMPTED, out, outCap); }
+void setAttempted(const char* v)            { writeKey(K_ATTEMPTED, v); }
+void clearAttempted()                       { removeKey(K_ATTEMPTED); }
+
+void getFailed(char* out, size_t outCap)    { readKey(K_FAILED, out, outCap); }
+void setFailed(const char* v)               { writeKey(K_FAILED, v); }
+void clearFailed()                          { removeKey(K_FAILED); }
+
+}  // namespace OtaState
+```
+
+- [ ] **Step 3: Verify it compiles in the device build (full build deferred to Task 9)**
+
+This file alone won't link until `main.cpp` references it; Task 5/9 will pull it in. For now, syntax-check only by ensuring no unresolved includes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add firmware/sensor-tag-wifi/include/ota_state.h \
+        firmware/sensor-tag-wifi/src/ota_state.cpp
+git commit -m "feat(sensor-tag-wifi): NVS-backed OTA state adapter"
+```
+
+---
+
+## Task 5: Build-time version + variant injection
+
+**Files:**
+- Create: `firmware/sensor-tag-wifi/get_version.py`
+- Modify: `firmware/sensor-tag-wifi/platformio.ini`
+
+- [ ] **Step 1: Write the PIO pre-script**
+
+`firmware/sensor-tag-wifi/get_version.py`:
+```python
+"""Inject FIRMWARE_VERSION as a build flag from `git describe`.
+
+Runs as a PlatformIO pre-script (extra_scripts = pre:get_version.py). Must
+be deterministic for cache hits — same git state must yield the same flag.
+"""
+import subprocess
+
+Import("env")  # noqa: F821 — provided by PlatformIO
+
+
+def _git_describe() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "describe", "--tags", "--always", "--dirty"],
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode("utf-8").strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+version = _git_describe()
+print(f"[get_version] FIRMWARE_VERSION={version}")
+env.Append(BUILD_FLAGS=[f'-DFIRMWARE_VERSION=\\"{version}\\"'])  # noqa: F821
+```
+
+- [ ] **Step 2: Wire pre-script + OTA_VARIANT into platformio.ini**
+
+Edit `firmware/sensor-tag-wifi/platformio.ini`. In `[env:xiao-c6-sht31]`, add `extra_scripts` and `OTA_VARIANT`:
+
+```ini
+[env:xiao-c6-sht31]
+extends = env:esp32-base
+board = esp32-c6-devkitm-1
+extra_scripts = pre:get_version.py
+lib_deps =
+    adafruit/Adafruit SHT31 Library@^2.2.2
+    knolleary/PubSubClient@^2.8
+    Networking
+build_flags =
+    ${env:esp32-base.build_flags}
+    -I../shared
+    -DCORE_DEBUG_LEVEL=3
+    -DSENSOR_SHT31
+    -DOTA_VARIANT=\"sht31\"
+build_src_filter =
+    +<*>
+    -<sensor_ds18b20.cpp>
+```
+
+Same edit to `[env:xiao-c6-ds18b20]`:
+
+```ini
+[env:xiao-c6-ds18b20]
+extends = env:esp32-base
+board = esp32-c6-devkitm-1
+extra_scripts = pre:get_version.py
+lib_deps =
+    pstolarz/OneWireNg@^0.14.1
+    milesburton/DallasTemperature@^3.11.0
+    knolleary/PubSubClient@^2.8
+    Networking
+lib_ignore = OneWire
+build_flags =
+    ${env:esp32-base.build_flags}
+    -I../shared
+    -DCORE_DEBUG_LEVEL=3
+    -DSENSOR_DS18B20
+    -DOTA_VARIANT=\"ds18b20\"
+build_src_filter =
+    +<*>
+    -<sensor_sht31.cpp>
+```
+
+- [ ] **Step 3: Verify pre-script fires**
+
+```bash
+cd firmware/sensor-tag-wifi
+pio run -e xiao-c6-sht31 -t clean
+pio run -e xiao-c6-sht31 2>&1 | grep "FIRMWARE_VERSION="
+```
+
+Expected: a line like `[get_version] FIRMWARE_VERSION=v0.x.y-...-dirty`. Build will fail later because `Ota::` is not yet referenced — that's fine; we only verify the script ran.
+
+If the build fails for *other* reasons (existing code regression), stop and investigate; the build was passing before this task.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add firmware/sensor-tag-wifi/get_version.py \
+        firmware/sensor-tag-wifi/platformio.ini
+git commit -m "build(sensor-tag-wifi): inject FIRMWARE_VERSION + OTA_VARIANT at build time"
+```
+
+---
+
+## Task 6: Dual-slot partition table
+
+**Files:**
+- Modify: `firmware/sensor-tag-wifi/partitions_tag.csv`
+
+- [ ] **Step 1: Replace the partition table**
+
+Replace the entire contents of `firmware/sensor-tag-wifi/partitions_tag.csv` with:
+
+```
+# Name,     Type, SubType, Offset,   Size,     Flags
+nvs,        data, nvs,     0x9000,   0x5000,
+otadata,    data, ota,     0xE000,   0x2000,
+app0,       app,  ota_0,   0x10000,  0x180000,
+app1,       app,  ota_1,   0x190000, 0x180000,
+spiffs,     data, spiffs,  0x310000, 0xF0000,
+```
+
+Total: 0x400000 (4 MB). Each app slot is 0x180000 (1.5 MB) — current binary is ~1 MB → 33% headroom.
+
+- [ ] **Step 2: Verify the device build still links**
+
+```bash
+cd firmware/sensor-tag-wifi
+pio run -e xiao-c6-sht31 -t clean
+pio run -e xiao-c6-sht31 2>&1 | tail -30
+```
+
+Expected: build succeeds with new partition layout. Look for `RAM:` and `Flash:` lines in the output and confirm `Flash` size used is well under `0x180000` (1.5 MB).
+
+If linker reports `region 'iram0_2_seg' overflowed` or similar, we've miscalculated — stop and revisit. The current binary is ~1 MB, well under 1.5 MB, so this should not happen.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add firmware/sensor-tag-wifi/partitions_tag.csv
+git commit -m "build(sensor-tag-wifi): dual 1.5MB OTA partitions for HTTP-pull updates"
+```
+
+---
+
+## Task 7: Extend config.h with OTA constants
+
+**Files:**
+- Modify: `firmware/sensor-tag-wifi/include/config.h`
+
+- [ ] **Step 1: Append OTA constants**
+
+Open `firmware/sensor-tag-wifi/include/config.h` and append after the `Payload` section:
+
+```cpp
+// =============================================================================
+// OTA
+// =============================================================================
+
+constexpr const char* OTA_DEFAULT_HOST     = "192.168.1.61";
+constexpr uint8_t     OTA_BATTERY_FLOOR_PCT = 20;
+constexpr uint32_t    OTA_HTTP_TIMEOUT_MS  = 30000;
+constexpr const char* NVS_KEY_OTA_HOST     = "ota_host";
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd firmware/sensor-tag-wifi
+pio run -e xiao-c6-sht31 2>&1 | tail -5
+```
+
+Expected: build succeeds (no behavioural change yet).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add firmware/sensor-tag-wifi/include/config.h
+git commit -m "feat(sensor-tag-wifi): config constants for OTA host + battery floor"
+```
+
+---
+
+## Task 8: ota.cpp — HTTP + esp_ota_* shell
+
+**Files:**
+- Create: `firmware/sensor-tag-wifi/include/ota.h`
+- Create: `firmware/sensor-tag-wifi/src/ota.cpp`
+
+This file is the side-effecting glue. All branching is delegated to the pure functions from Tasks 1–3, so device-only and not native-tested. Pattern mirrors `firmware/collector/src/ota_self.cpp` for the streaming download.
+
+- [ ] **Step 1: Write the header**
+
+`firmware/sensor-tag-wifi/include/ota.h`:
+```cpp
+#pragma once
+
+#include <cstdint>
+
+namespace Ota {
+    void validateOnBoot();
+    void onPublishSuccess();
+    void checkAndApply(uint8_t batteryPct);
+}
+```
+
+- [ ] **Step 2: Write the implementation**
+
+`firmware/sensor-tag-wifi/src/ota.cpp`:
+```cpp
+#include "ota.h"
+
+#include <Arduino.h>
+#include <Preferences.h>
+#include <esp_http_client.h>
+#include <esp_ota_ops.h>
+#include <cstring>
+
+#include "config.h"
+#include "ota_decision.h"
+#include "ota_manifest.h"
+#include "ota_sha256.h"
+#include "ota_state.h"
+
+#ifndef FIRMWARE_VERSION
+#define FIRMWARE_VERSION "unknown"
+#endif
+
+#ifndef OTA_VARIANT
+#define OTA_VARIANT "unknown"
+#endif
+
+namespace {
+
+void readOtaHost(char* out, size_t outCap) {
+    Preferences p;
+    p.begin(NVS_NAMESPACE, true);
+    String v = p.getString(NVS_KEY_OTA_HOST, OTA_DEFAULT_HOST);
+    p.end();
+    size_t n = v.length() < outCap ? v.length() : outCap - 1;
+    memcpy(out, v.c_str(), n);
+    out[n] = '\0';
+}
+
+bool fetchManifestText(const char* url, char* buf, size_t bufCap, int& outLen) {
+    esp_http_client_config_t cfg = {};
+    cfg.url        = url;
+    cfg.timeout_ms = OTA_HTTP_TIMEOUT_MS;
+
+    esp_http_client_handle_t client = esp_http_client_init(&cfg);
+    if (!client) return false;
+
+    bool ok = false;
+    if (esp_http_client_open(client, 0) == ESP_OK) {
+        esp_http_client_fetch_headers(client);
+        int total = 0;
+        while (total < (int)bufCap - 1) {
+            int n = esp_http_client_read(client, buf + total, (int)bufCap - 1 - total);
+            if (n < 0) { total = -1; break; }
+            if (n == 0) break;
+            total += n;
+        }
+        if (total >= 0) {
+            buf[total] = '\0';
+            outLen = total;
+            ok = (esp_http_client_get_status_code(client) == 200);
+        }
+        esp_http_client_close(client);
+    }
+    esp_http_client_cleanup(client);
+    return ok;
+}
+
+bool downloadAndStream(const Manifest& m, const esp_partition_t* target) {
+    esp_ota_handle_t handle = 0;
+    if (esp_ota_begin(target, OTA_WITH_SEQUENTIAL_WRITES, &handle) != ESP_OK) {
+        Serial.println("[OTA] esp_ota_begin failed");
+        return false;
+    }
+
+    esp_http_client_config_t cfg = {};
+    cfg.url        = m.url;
+    cfg.timeout_ms = OTA_HTTP_TIMEOUT_MS;
+    esp_http_client_handle_t client = esp_http_client_init(&cfg);
+    if (!client) { esp_ota_abort(handle); return false; }
+
+    bool ok = (esp_http_client_open(client, 0) == ESP_OK);
+    if (ok) esp_http_client_fetch_headers(client);
+
+    Sha256Streamer hasher;
+    uint8_t buf[1024];
+    size_t total = 0;
+    while (ok) {
+        int n = esp_http_client_read(client, reinterpret_cast<char*>(buf), sizeof(buf));
+        if (n < 0) { ok = false; break; }
+        if (n == 0) break;
+        if (esp_ota_write(handle, buf, n) != ESP_OK) { ok = false; break; }
+        hasher.update(buf, n);
+        total += n;
+    }
+
+    esp_http_client_close(client);
+    esp_http_client_cleanup(client);
+
+    if (!ok) {
+        Serial.printf("[OTA] download failed at %u bytes\n", (unsigned)total);
+        esp_ota_abort(handle);
+        return false;
+    }
+    if (total != m.size) {
+        Serial.printf("[OTA] size mismatch got=%u want=%u\n",
+                      (unsigned)total, (unsigned)m.size);
+        esp_ota_abort(handle);
+        return false;
+    }
+
+    char hex[65] = {};
+    hasher.finalizeToHex(hex);
+    if (!hasher.matches(m.sha256)) {
+        Serial.printf("[OTA] sha256 mismatch got=%s want=%s\n", hex, m.sha256);
+        esp_ota_abort(handle);
+        return false;
+    }
+
+    if (esp_ota_end(handle) != ESP_OK) {
+        Serial.println("[OTA] esp_ota_end failed");
+        return false;
+    }
+    Serial.printf("[OTA] download bytes=%u sha256_ok=true\n", (unsigned)total);
+    return true;
+}
+
+}  // namespace
+
+namespace Ota {
+
+void validateOnBoot() {
+    char attempted[32] = {};
+    OtaState::getAttempted(attempted, sizeof(attempted));
+
+    const esp_partition_t* running = esp_ota_get_running_partition();
+    esp_ota_img_states_t state = ESP_OTA_IMG_UNDEFINED;
+    bool isPending = false;
+    if (running && esp_ota_get_state_partition(running, &state) == ESP_OK) {
+        isPending = (state == ESP_OTA_IMG_PENDING_VERIFY);
+    }
+
+    ValidateAction action = validateOnBootAction(FIRMWARE_VERSION, attempted, isPending);
+    Serial.printf("[OTA] validate version=%s attempted=%s pending=%d action=%d\n",
+                  FIRMWARE_VERSION, attempted, (int)isPending, (int)action);
+
+    switch (action) {
+        case ValidateAction::NoOp:
+            break;
+        case ValidateAction::ClearAttempted:
+            OtaState::clearAttempted();
+            OtaState::clearFailed();
+            break;
+        case ValidateAction::RecordFailed:
+            OtaState::setFailed(attempted);
+            OtaState::clearAttempted();
+            break;
+    }
+}
+
+void onPublishSuccess() {
+    const esp_partition_t* running = esp_ota_get_running_partition();
+    esp_ota_img_states_t state = ESP_OTA_IMG_UNDEFINED;
+    if (!running || esp_ota_get_state_partition(running, &state) != ESP_OK) return;
+    if (state != ESP_OTA_IMG_PENDING_VERIFY) return;
+
+    Serial.println("[OTA] first publish ok — marking firmware valid");
+    esp_ota_mark_app_valid_cancel_rollback();
+    OtaState::clearAttempted();
+    OtaState::clearFailed();
+}
+
+void checkAndApply(uint8_t batteryPct) {
+    char host[64];
+    readOtaHost(host, sizeof(host));
+
+    char manifestUrl[160];
+    snprintf(manifestUrl, sizeof(manifestUrl),
+             "http://%s/firmware/sensor-tag-wifi/%s/manifest.json",
+             host, OTA_VARIANT);
+
+    char body[1024];
+    int len = 0;
+    if (!fetchManifestText(manifestUrl, body, sizeof(body), len)) {
+        Serial.println("[OTA] manifest fetch failed");
+        return;
+    }
+
+    Manifest m {};
+    if (!parseManifest(body, (size_t)len, m)) {
+        Serial.println("[OTA] manifest parse failed");
+        return;
+    }
+
+    char failed[32] = {};
+    OtaState::getFailed(failed, sizeof(failed));
+
+    Serial.printf("[OTA] check version=%s manifest=%s failed=%s battery=%u\n",
+                  FIRMWARE_VERSION, m.version, failed, batteryPct);
+
+    if (!shouldApply(FIRMWARE_VERSION, m.version, failed, batteryPct)) {
+        Serial.println("[OTA] check → skip");
+        return;
+    }
+
+    const esp_partition_t* target = esp_ota_get_next_update_partition(nullptr);
+    if (!target) { Serial.println("[OTA] no inactive partition"); return; }
+
+    if (!downloadAndStream(m, target)) return;
+
+    if (esp_ota_set_boot_partition(target) != ESP_OK) {
+        Serial.println("[OTA] set_boot_partition failed");
+        return;
+    }
+    OtaState::setAttempted(m.version);
+    Serial.printf("[OTA] reboot into %s\n", m.version);
+    Serial.flush();
+    esp_restart();
+}
+
+}  // namespace Ota
+```
+
+- [ ] **Step 3: Verify the device build links**
+
+```bash
+cd firmware/sensor-tag-wifi
+pio run -e xiao-c6-sht31 2>&1 | tail -10
+```
+
+Expected: build succeeds. Code is unreachable (nothing calls `Ota::` yet) so no behavioural change.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add firmware/sensor-tag-wifi/include/ota.h \
+        firmware/sensor-tag-wifi/src/ota.cpp
+git commit -m "feat(sensor-tag-wifi): HTTP-pull OTA shell (validate/publish-hook/apply)"
+```
+
+---
+
+## Task 9: Wire OTA into main.cpp
+
+**Files:**
+- Modify: `firmware/sensor-tag-wifi/src/main.cpp`
+
+- [ ] **Step 1: Add the include**
+
+Edit `firmware/sensor-tag-wifi/src/main.cpp`. Insert after the `#include "serial_console.h"` line:
+
+```cpp
+#include "ota.h"
+```
+
+- [ ] **Step 2: Track last battery reading and add publish hook**
+
+Inside the anonymous namespace, after the `RTC_DATA_ATTR uint16_t rtcSampleCounter = 0;` line, add:
+
+```cpp
+uint8_t lastBatteryPct = 0;
+```
+
+In `sampleAndEnqueue()`, after `r.battery_pct = Battery::readPercent();`, add:
+
+```cpp
+    lastBatteryPct = r.battery_pct;
+```
+
+In `drainBuffer()`, change the publish loop from:
+```cpp
+        if (!MqttClient::publish(deviceId, r)) break;
+        RingBuffer::popOldest();
+        sent++;
+```
+to:
+```cpp
+        if (!MqttClient::publish(deviceId, r)) break;
+        RingBuffer::popOldest();
+        sent++;
+        Ota::onPublishSuccess();
+```
+
+- [ ] **Step 3: Add validateOnBoot + checkAndApply to setup()**
+
+In `setup()`, immediately after `initDeviceId();` and the device-ID print:
+
+```cpp
+    Ota::validateOnBoot();
+```
+
+In `setup()`, immediately before the `Serial.printf("[MAIN] sleeping ...` line:
+
+```cpp
+    if (rtcSampleCounter == 0 && lastBatteryPct > 0) {
+        Ota::checkAndApply(lastBatteryPct);
+    }
+```
+
+(Guard ensures we only check OTA on cycles where we just uploaded — `rtcSampleCounter == 0` after a successful drain.)
+
+- [ ] **Step 4: Verify the build succeeds**
+
+```bash
+cd firmware/sensor-tag-wifi
+pio run -e xiao-c6-sht31 2>&1 | tail -10
+pio run -e xiao-c6-ds18b20 2>&1 | tail -10
+```
+
+Expected: both build successfully.
+
+- [ ] **Step 5: Run native tests as a regression check**
+
+```bash
+cd firmware/sensor-tag-wifi
+pio test -e native
+```
+
+Expected: all tests still pass (6 payload + 5 manifest + 6 decision + 4 validation + 5 sha256 = 26 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add firmware/sensor-tag-wifi/src/main.cpp
+git commit -m "feat(sensor-tag-wifi): wire OTA validate/hook/check into main flow"
+```
+
+---
+
+## Task 10: Serial console accepts `set ota_host`
+
+**Files:**
+- Modify: `firmware/sensor-tag-wifi/src/serial_console.cpp`
+
+- [ ] **Step 1: Add ota_host to known keys**
+
+Edit `firmware/sensor-tag-wifi/src/serial_console.cpp`. Replace the `knownKeys[]` initializer with:
+
+```cpp
+const char* knownKeys[] = {
+    "hive_id", "collector_mac", "day_start", "day_end", "read_interval",
+    "weight_off", "weight_scl", "mqtt_host", "mqtt_port", "mqtt_user", "mqtt_pass",
+    "tag_name", "tag_name_2", "adv_interval",
+    "wifi_ssid", "wifi_pass",
+    "sample_int", "upload_every",
+    "ota_host"
+};
+```
+
+The existing string-detection branch in `printKeyValue()` already handles `ota_host` (it's a string with content; the early `prefs.getString` path catches it). The `set` handler already routes string values containing dots/letters to `putString`, so no further change is needed.
+
+- [ ] **Step 2: Verify the build**
+
+```bash
+cd firmware/sensor-tag-wifi
+pio run -e xiao-c6-sht31 2>&1 | tail -5
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add firmware/sensor-tag-wifi/src/serial_console.cpp
+git commit -m "feat(sensor-tag-wifi): expose ota_host to serial provisioning console"
+```
+
+---
+
+## Task 11: provision_tag.py gains --ota-host
+
+**Files:**
+- Modify: `tools/provision_tag.py`
+
+- [ ] **Step 1: Refactor to accept CLI args and add --ota-host**
+
+Replace the entire contents of `tools/provision_tag.py` with:
+
+```python
+#!/usr/bin/env python3
+"""Provision a sensor-tag-wifi via its serial console.
+
+Waits for the C6's USB CDC to appear, sends provisioning commands over the
+console, then exits. Override defaults via CLI flags.
+"""
+import argparse
+import glob
+import sys
+import time
+import serial
+
+
+PORT_GLOB = "/dev/cu.usbmodem*"
+BAUD = 115200
+SHELL_PROMPT = b"> "
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--wifi-ssid", default="IOT")
+    p.add_argument("--wifi-pass", default="4696930759")
+    p.add_argument("--mqtt-host", default="192.168.1.82")
+    p.add_argument("--mqtt-port", default="1883")
+    p.add_argument("--mqtt-user", default="hivesense")
+    p.add_argument("--mqtt-pass", default="hivesense")
+    p.add_argument("--tag-name",  default="bench-ds18b20")
+    p.add_argument("--sample-int", default="30")
+    p.add_argument("--upload-every", default="1")
+    p.add_argument("--ota-host",  default="192.168.1.61")
+    return p.parse_args()
+
+
+def build_commands(a: argparse.Namespace) -> list[str]:
+    return [
+        f"set wifi_ssid {a.wifi_ssid}",
+        f"set wifi_pass {a.wifi_pass}",
+        f"set mqtt_host {a.mqtt_host}",
+        f"set mqtt_port {a.mqtt_port}",
+        f"set mqtt_user {a.mqtt_user}",
+        f"set mqtt_pass {a.mqtt_pass}",
+        f"set tag_name {a.tag_name}",
+        f"set sample_int {a.sample_int}",
+        f"set upload_every {a.upload_every}",
+        f"set ota_host {a.ota_host}",
+        "list",
+        "exit",
+    ]
+
+
+def find_port(timeout_s: float = 60.0) -> str:
+    print(f"[prov] waiting up to {timeout_s:.0f}s for {PORT_GLOB} ...")
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        matches = glob.glob(PORT_GLOB)
+        if matches:
+            port = matches[0]
+            print(f"[prov] found {port}")
+            return port
+        time.sleep(0.1)
+    print("[prov] port never appeared — reconnect the C6 USB cable")
+    sys.exit(1)
+
+
+def open_serial(port: str, timeout_s: float = 5.0) -> serial.Serial:
+    deadline = time.time() + timeout_s
+    last_err = None
+    while time.time() < deadline:
+        try:
+            return serial.Serial(port, BAUD, timeout=0.05)
+        except (serial.SerialException, OSError) as err:
+            last_err = err
+            time.sleep(0.05)
+    raise RuntimeError(f"could not open {port}: {last_err}")
+
+
+def _read(ser: serial.Serial, n: int) -> bytes:
+    try:
+        return ser.read(n)
+    except serial.SerialException:
+        time.sleep(0.05)
+        return b""
+
+
+def wait_for(ser: serial.Serial, needle: bytes, timeout_s: float) -> bool:
+    buf = bytearray()
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        chunk = _read(ser, 256)
+        if chunk:
+            buf.extend(chunk)
+            sys.stdout.write(chunk.decode(errors="replace"))
+            sys.stdout.flush()
+            if needle in buf:
+                return True
+    return False
+
+
+def drain(ser: serial.Serial, duration_s: float) -> None:
+    end = time.time() + duration_s
+    while time.time() < end:
+        chunk = _read(ser, 256)
+        if chunk:
+            sys.stdout.write(chunk.decode(errors="replace"))
+            sys.stdout.flush()
+
+
+def main() -> None:
+    args = parse_args()
+    commands = build_commands(args)
+
+    port = find_port()
+    with open_serial(port) as ser:
+        print("[prov] opened — probing for console")
+        ser.write(b"help\r")
+        if not wait_for(ser, SHELL_PROMPT, timeout_s=5.0):
+            print("\n[prov] no shell prompt — reconnect the C6 and retry")
+            return
+
+        for cmd in commands:
+            print(f"\n[prov] >> {cmd}")
+            ser.write(cmd.encode() + b"\r")
+            wait_for(ser, SHELL_PROMPT, timeout_s=3.0)
+
+        print("\n[prov] provisioned — tailing serial for 60s")
+        drain(ser, 60.0)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Sanity-check the script**
+
+```bash
+python3 tools/provision_tag.py --help
+```
+
+Expected: argparse `--help` output listing all flags including `--ota-host`. No serial port required.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/provision_tag.py
+git commit -m "feat(provision_tag): expose --ota-host plus other provisioning flags"
+```
+
+---
+
+## Task 12: nginx fragment for /firmware/
+
+**Files:**
+- Modify: `deploy/web/nginx/combsense-web.conf`
+
+- [ ] **Step 1: Add the firmware location to the :80 server**
+
+Edit `deploy/web/nginx/combsense-web.conf`. Replace the `:80` server block with:
+
+```nginx
+# --- HTTP (:80) — ACME challenge passthrough; firmware on LAN; rest → HTTPS
+server {
+    listen 80;
+    listen [::]:80;
+    server_name dashboard.combsense.com 192.168.1.61;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    # LAN-only firmware OTA pull. Integrity is sha256 in the manifest;
+    # the allow/deny block prevents accidental WAN exposure.
+    location /firmware/ {
+        alias /var/www/combsense-firmware/;
+        autoindex off;
+        default_type application/octet-stream;
+        types { application/json json; application/octet-stream bin; }
+
+        allow 192.168.0.0/16;
+        deny all;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+```
+
+The `server_name` now also accepts `192.168.1.61` so devices using the IP form bypass the HTTPS redirect for `/firmware/` requests.
+
+- [ ] **Step 2: Deploy to the LXC**
+
+```bash
+ssh natas@192.168.1.61 "sudo mkdir -p /var/www/combsense-firmware/sensor-tag-wifi/sht31 /var/www/combsense-firmware/sensor-tag-wifi/ds18b20"
+
+scp deploy/web/nginx/combsense-web.conf natas@192.168.1.61:/tmp/combsense-web.conf
+ssh natas@192.168.1.61 "sudo mv /tmp/combsense-web.conf /etc/nginx/sites-available/combsense-web && sudo nginx -t && sudo systemctl reload nginx"
+```
+
+Expected: `nginx -t` reports `syntax is ok` and `test is successful`. Reload returns 0.
+
+- [ ] **Step 3: Sanity-check the route**
+
+```bash
+# From a workstation on 192.168.x.x (not the LXC itself):
+curl -i http://192.168.1.61/firmware/
+```
+
+Expected: `HTTP/1.1 403 Forbidden` (autoindex off, no index file). 403 is the success signal — confirms the location matches and is reachable; no redirect to HTTPS.
+
+If it returns `301 Moved Permanently` to `https://...`, the `location /firmware/` block isn't matching — verify it's *before* the catch-all `location /`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy/web/nginx/combsense-web.conf
+git commit -m "deploy(web): nginx fragment for LAN-only /firmware/ OTA pulls"
+```
+
+---
+
+## Task 13: publish-firmware.sh
+
+**Files:**
+- Create: `deploy/web/publish-firmware.sh`
+
+- [ ] **Step 1: Write the publish script**
+
+`deploy/web/publish-firmware.sh`:
+```bash
+#!/usr/bin/env bash
+# Build sensor-tag-wifi firmware for <variant>, upload to the OTA host, and
+# publish a fresh manifest. Run from the repo root.
+#
+# Usage:  deploy/web/publish-firmware.sh <sht31|ds18b20>
+
+set -euo pipefail
+
+VARIANT="${1:-}"
+if [[ "$VARIANT" != "sht31" && "$VARIANT" != "ds18b20" ]]; then
+    echo "usage: $0 <sht31|ds18b20>" >&2
+    exit 2
+fi
+
+OTA_HOST="${OTA_HOST:-192.168.1.61}"
+OTA_USER="${OTA_USER:-natas}"
+OTA_ROOT="/var/www/combsense-firmware/sensor-tag-wifi/${VARIANT}"
+WEB_BASE="http://${OTA_HOST}/firmware/sensor-tag-wifi/${VARIANT}"
+
+cd firmware/sensor-tag-wifi
+
+VERSION="$(git describe --tags --always)"
+echo "[publish] variant=${VARIANT} version=${VERSION}"
+
+pio run -e "xiao-c6-${VARIANT}"
+BIN=".pio/build/xiao-c6-${VARIANT}/firmware.bin"
+[[ -f "$BIN" ]] || { echo "build did not produce ${BIN}" >&2; exit 1; }
+
+SHA="$(shasum -a 256 "$BIN" | awk '{print $1}')"
+SIZE="$(stat -f '%z' "$BIN" 2>/dev/null || stat -c '%s' "$BIN")"
+echo "[publish] sha256=${SHA} size=${SIZE}"
+
+MANIFEST=$(mktemp)
+cat > "$MANIFEST" <<EOF
+{
+  "version": "${VERSION}",
+  "url": "${WEB_BASE}/${VERSION}/firmware.bin",
+  "sha256": "${SHA}",
+  "size": ${SIZE}
+}
+EOF
+
+scp "$BIN" "${OTA_USER}@${OTA_HOST}:/tmp/firmware.bin"
+scp "$MANIFEST" "${OTA_USER}@${OTA_HOST}:/tmp/manifest.json"
+rm -f "$MANIFEST"
+
+ssh "${OTA_USER}@${OTA_HOST}" sudo bash -s <<EOF
+set -euo pipefail
+mkdir -p "${OTA_ROOT}/${VERSION}"
+mv /tmp/firmware.bin "${OTA_ROOT}/${VERSION}/firmware.bin"
+chmod 644 "${OTA_ROOT}/${VERSION}/firmware.bin"
+mv /tmp/manifest.json "${OTA_ROOT}/manifest.json"
+chmod 644 "${OTA_ROOT}/manifest.json"
+EOF
+
+echo "[publish] done — manifest at ${WEB_BASE}/manifest.json"
+```
+
+- [ ] **Step 2: Make it executable**
+
+```bash
+chmod +x deploy/web/publish-firmware.sh
+```
+
+- [ ] **Step 3: Sanity-check via dry argv handling**
+
+```bash
+deploy/web/publish-firmware.sh
+```
+
+Expected: `usage: deploy/web/publish-firmware.sh <sht31|ds18b20>` on stderr, exit code 2.
+
+```bash
+deploy/web/publish-firmware.sh bogus
+```
+
+Expected: same usage error, exit code 2.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy/web/publish-firmware.sh
+git commit -m "deploy(web): publish-firmware.sh — build, upload, manifest in one shot"
+```
+
+---
+
+## Task 14: Bootstrap publish + first OTA
+
+**Files:** none (operational task).
+
+- [ ] **Step 1: Publish current firmware as the seed manifest**
+
+For both variants, the running firmware on a device must match the manifest version on first run, otherwise it'll try to update on first wake (which is fine, but adds noise to the test).
+
+Easiest path: publish first, then flash the same firmware over USB so the device boots with `FIRMWARE_VERSION` matching the manifest.
+
+```bash
+# From the repo root
+deploy/web/publish-firmware.sh ds18b20
+```
+
+Expected: script exits 0; `curl http://192.168.1.61/firmware/sensor-tag-wifi/ds18b20/manifest.json` from the LAN returns the JSON manifest with the version produced by `git describe`.
+
+```bash
+curl http://192.168.1.61/firmware/sensor-tag-wifi/ds18b20/manifest.json
+curl -I http://192.168.1.61/firmware/sensor-tag-wifi/ds18b20/$(git describe --tags --always)/firmware.bin
+```
+
+Second curl should return `HTTP/1.1 200 OK` and `Content-Type: application/octet-stream`.
+
+- [ ] **Step 2: Flash the device with the same version**
+
+```bash
+cd firmware/sensor-tag-wifi
+pio run -e xiao-c6-ds18b20 -t upload
+pio device monitor -e xiao-c6-ds18b20
+```
+
+Expected serial output: `[OTA] validate version=<git-describe> attempted= pending=0 action=0` (NoOp); after first publish: `[OTA] check version=<v> manifest=<v> failed= battery=<n>` followed by `[OTA] check → skip`.
+
+- [ ] **Step 3: Commit a no-op marker (optional)**
+
+If the publish workflow surfaces any tweaks to the script during real use, capture them here. Otherwise skip the commit.
+
+---
+
+## Task 15: Hardware smoke tests
+
+**Files:** none — operational; record results in the runbook.
+
+Each scenario from the spec's "Hardware smoke tests" matrix. Tail serial during each.
+
+- [ ] **Step 1: Happy-path upgrade**
+
+Make a trivial change (e.g. bump a log string in `main.cpp`), commit, push to a tag, then:
+
+```bash
+git tag -a v0.2.0-ota-test -m "OTA smoke test"
+deploy/web/publish-firmware.sh ds18b20
+```
+
+On the device: tail serial across 1–2 wake cycles. Expected log lines:
+```
+[OTA] check version=<old> manifest=v0.2.0-ota-test failed= battery=<n>
+[OTA] download bytes=<n> sha256_ok=true
+[OTA] reboot into v0.2.0-ota-test
+... (reboot)
+[OTA] validate version=v0.2.0-ota-test attempted=v0.2.0-ota-test pending=1 action=0
+... (after first publish)
+[OTA] first publish ok — marking firmware valid
+```
+
+Verify a fresh sample arrives in InfluxDB:
+```bash
+ssh root@192.168.1.19 "influx query --token \$(jq -r .ios_read_token /root/.combsense-tsdb-creds 2>/dev/null || cat /root/.combsense-tsdb-creds | grep ios_read_token | cut -d'=' -f2) --org combsense 'from(bucket:\"combsense\") |> range(start:-10m) |> filter(fn: (r) => r.sensor_id == \"<your-id>\") |> last()'"
+```
+
+- [ ] **Step 2: Same-version no-op**
+
+Re-run `deploy/web/publish-firmware.sh ds18b20` without changing code. Expected serial: `[OTA] check ... → skip`. nginx access log shows `GET /firmware/.../manifest.json` but no GET on `firmware.bin`.
+
+- [ ] **Step 3: SHA-256 mismatch**
+
+```bash
+ssh natas@192.168.1.61 "sudo bash -c 'V=\$(jq -r .version /var/www/combsense-firmware/sensor-tag-wifi/ds18b20/manifest.json); printf \"\\xff\" | dd of=/var/www/combsense-firmware/sensor-tag-wifi/ds18b20/\$V/firmware.bin bs=1 count=1 conv=notrunc'"
+```
+
+Bump version in manifest by hand or republish to invalidate the cached check. Tail serial. Expected: `[OTA] sha256 mismatch got=<x> want=<y>` then sleep, no boot-partition change.
+
+Restore by re-running `publish-firmware.sh`.
+
+- [ ] **Step 4: Failed-publish rollback**
+
+In a temporary branch, intentionally break MQTT (e.g. set the wrong `mqtt_host` default in code or add a `return false` in `MqttClient::publish`). Tag and publish.
+
+Expected: device boots new firmware → tries to publish → fails → on next reset, bootloader rolls back → old firmware sees `attempted != FIRMWARE_VERSION` and records `failed=<broken-version>`. Subsequent wakes log `[OTA] check ... → skip` because manifest matches `failed`.
+
+Recover by reverting the broken commit, retagging, and republishing — the new tag differs from `failed`, so the device will attempt the upgrade.
+
+- [ ] **Step 5: Battery floor**
+
+Build with `-DOTA_BATTERY_FLOOR_PCT=99` (override via PIO env or temporarily edit `config.h`), flash, publish a new version. Expected: `[OTA] check ... battery=<n> → skip`. Revert the override after the test.
+
+- [ ] **Step 6: Capture results**
+
+Append observed serial lines for each scenario to a runbook section (e.g. add to `.mex/ROUTER.md` "TSDB / firmware ops" or create `docs/superpowers/runbooks/sensor-tag-wifi-ota.md` if it doesn't exist).
+
+```bash
+git add docs/superpowers/runbooks/sensor-tag-wifi-ota.md  # if created
+git commit -m "docs(sensor-tag-wifi): OTA hardware smoke test results"
+```
+
+If no doc was created, no commit needed.
+
+---
+
+## Task 16: Update .mex/ROUTER.md
+
+**Files:**
+- Modify: `.mex/ROUTER.md`
+
+- [ ] **Step 1: Add OTA bullet to "Completed" under sensor-tag-wifi**
+
+Edit `.mex/ROUTER.md`. In the `Sensor tag WiFi variant` block, append a bullet:
+
+```
+  - HTTP-pull OTA on wake (manifest at http://192.168.1.61/firmware/sensor-tag-wifi/<variant>/manifest.json), sha256-verified, dual 1.5 MB OTA slots, bootloader auto-rollback if first publish fails. Publish via `deploy/web/publish-firmware.sh <variant>`.
+```
+
+- [ ] **Step 2: Update Routing Table**
+
+Add a row:
+
+| Sensor-tag-wifi OTA | `firmware/sensor-tag-wifi/src/ota*.cpp` + `deploy/web/publish-firmware.sh` |
+
+- [ ] **Step 3: Update last_updated and Phase line**
+
+Bump frontmatter `last_updated` to today's date with a one-line summary (e.g. `2026-04-24 (sensor-tag-wifi OTA shipped — HTTP-pull from combsense-web LXC)`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .mex/ROUTER.md
+git commit -m "docs(mex): note sensor-tag-wifi OTA pipeline in ROUTER"
+```
+
+---
+
+## Self-Review
+
+Spec coverage check (against `docs/superpowers/specs/2026-04-24-sensor-tag-wifi-ota-design.md`):
+
+| Spec requirement | Task |
+|---|---|
+| `Ota::validateOnBoot/onPublishSuccess/checkAndApply` API | Task 8 (impl), Task 9 (wiring) |
+| `ota_manifest` pure parser | Task 1 |
+| `ota_decision` pure functions | Task 2 |
+| `ota_state` Preferences adapter | Task 4 |
+| `ota_sha256` streaming verifier | Task 3 |
+| `include/config.h` extensions | Task 7 |
+| Dual 1.5 MB partition table | Task 6 |
+| `extra_scripts = pre:get_version.py` + `OTA_VARIANT` | Task 5 |
+| `serial_console` accepts `set ota_host` | Task 10 |
+| `provision_tag.py --ota-host` | Task 11 |
+| nginx fragment + LXC bootstrap | Task 12 |
+| `publish-firmware.sh` | Task 13 |
+| Native unit tests (manifest/decision/validation/sha256) | Tasks 1-3 |
+| Hardware smoke tests | Task 15 |
+| Runbook hooks | Tasks 14-16 |
+
+All 26 native tests cover every row of the `shouldApply` and `validateOnBootAction` truth tables in the spec.
+
+**Type consistency check:** `Manifest`, `ValidateAction`, `Sha256Streamer`, `OtaState::*` names, `Ota::*` names match across all tasks. The native env's `build_src_filter` accumulates correctly: `payload.cpp`, `ota_manifest.cpp`, `ota_decision.cpp`, `ota_sha256.cpp` (no transient missing-symbol gap between tasks).
+
+**No placeholders:** every step contains the actual code, command, or file edit needed.

--- a/docs/superpowers/plans/2026-04-25-sensor-tag-wifi-fleet-visibility.md
+++ b/docs/superpowers/plans/2026-04-25-sensor-tag-wifi-fleet-visibility.md
@@ -1,0 +1,951 @@
+# sensor-tag-wifi: fleet visibility & battery telemetry — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-reading firmware version (`v`), raw battery voltage (`vbat_mV`), and post-connect WiFi RSSI (`rssi`) to the sensor-tag-wifi MQTT payload, plus matching Telegraf parser entries and unit-test coverage.
+
+**Architecture:** Decompose `Battery::readPercent()` into a pure inline `percentFromMillivolts()` (testable on the native env) plus an Arduino-dependent `readMillivolts()`. Add `vbat_mV` to the `Reading` POD (per-sample, RTC-persisted). Pass `fwVersion` and `rssi` as parameters to `Payload::serialize()` (per-publish, not per-sample). Telegraf gets all three as Influx fields, never tags.
+
+**Tech Stack:** C++17, PlatformIO (Arduino + native test env), Unity test framework, Telegraf json_v2 parser, InfluxDB 2.x.
+
+**Spec:** [docs/superpowers/specs/2026-04-25-sensor-tag-wifi-fleet-visibility-design.md](../specs/2026-04-25-sensor-tag-wifi-fleet-visibility-design.md)
+
+**Branch policy:** Work on `dev`. Per-task commits. Never commit to `main`.
+
+**After every commit (and before moving to the next task):** run `pio test -e native -d firmware/sensor-tag-wifi` and confirm 0 failures.
+
+---
+
+## File Structure
+
+| File | Role | Action |
+|---|---|---|
+| `firmware/sensor-tag-wifi/src/battery.h` | Battery interface | **Modify** — add `readMillivolts()`, inline `percentFromMillivolts()` |
+| `firmware/sensor-tag-wifi/src/battery.cpp` | Battery impl (Arduino-dependent) | **Modify** — split ADC sweep into `readMillivolts()`, `readPercent()` becomes composition |
+| `firmware/sensor-tag-wifi/test/test_battery_math/test_battery_math.cpp` | Native unit tests for pure conversion | **Create** |
+| `firmware/sensor-tag-wifi/include/reading.h` | Reading POD | **Modify** — add `uint16_t vbat_mV` field |
+| `firmware/sensor-tag-wifi/include/payload.h` | Payload serializer interface | **Modify** — extend `serialize()` signature |
+| `firmware/sensor-tag-wifi/src/payload.cpp` | Payload serializer impl | **Modify** — emit `v`, `vbat_mV`, `rssi` |
+| `firmware/sensor-tag-wifi/test/test_payload/test_payload.cpp` | Payload unit tests | **Modify** — update 6 tests + add 1 new |
+| `firmware/sensor-tag-wifi/src/main.cpp` | Sample wake cycle | **Modify** — populate `r.vbat_mV` |
+| `firmware/sensor-tag-wifi/src/mqtt_client.cpp` | MQTT publish | **Modify** — capture `WiFi.RSSI()`, pass `FIRMWARE_VERSION` and rssi to serialize |
+| `firmware/sensor-tag-wifi/platformio.ini` | Build config | **Modify** — add `+<battery.cpp>` to native filter (ADC stub) — N/A, see Task 1 note |
+| `deploy/tsdb/telegraf-combsense.conf` | Telegraf parser (mirror) | **Modify** — add 3 field blocks |
+
+---
+
+## Task 1: Pure `percentFromMillivolts()` with native unit tests (TDD)
+
+**Files:**
+- Modify: `firmware/sensor-tag-wifi/src/battery.h`
+- Create: `firmware/sensor-tag-wifi/test/test_battery_math/test_battery_math.cpp`
+
+**Note on native build:** `percentFromMillivolts` is `inline` in `battery.h`. The native env doesn't include `battery.cpp` (Arduino-dependent), but inline functions in headers don't need a `.cpp` — the native test simply `#include "battery.h"` and the inline body is available at compile time. No `platformio.ini` change required. The other `battery.h` declaration (`readMillivolts`) is decl-only and the linker won't try to resolve it because the test never calls it.
+
+- [ ] **Step 1: Write the failing native tests**
+
+Create `firmware/sensor-tag-wifi/test/test_battery_math/test_battery_math.cpp`:
+
+```cpp
+#include <unity.h>
+#include "battery.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_full_voltage_returns_100() {
+    TEST_ASSERT_EQUAL_UINT8(100, Battery::percentFromMillivolts(4200));
+}
+
+void test_above_full_clamps_to_100() {
+    TEST_ASSERT_EQUAL_UINT8(100, Battery::percentFromMillivolts(4500));
+}
+
+void test_empty_voltage_returns_0() {
+    TEST_ASSERT_EQUAL_UINT8(0, Battery::percentFromMillivolts(3300));
+}
+
+void test_below_empty_clamps_to_0() {
+    TEST_ASSERT_EQUAL_UINT8(0, Battery::percentFromMillivolts(3100));
+}
+
+void test_midpoint_returns_50() {
+    // (3750 - 3300) * 100 / (4200 - 3300) = 45000/900 = 50
+    TEST_ASSERT_EQUAL_UINT8(50, Battery::percentFromMillivolts(3750));
+}
+
+void test_three_quarters_returns_75() {
+    // (3975 - 3300) * 100 / 900 = 67500/900 = 75
+    TEST_ASSERT_EQUAL_UINT8(75, Battery::percentFromMillivolts(3975));
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_full_voltage_returns_100);
+    RUN_TEST(test_above_full_clamps_to_100);
+    RUN_TEST(test_empty_voltage_returns_0);
+    RUN_TEST(test_below_empty_clamps_to_0);
+    RUN_TEST(test_midpoint_returns_50);
+    RUN_TEST(test_three_quarters_returns_75);
+    return UNITY_END();
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail to compile**
+
+```
+cd firmware/sensor-tag-wifi && pio test -e native -f test_battery_math
+```
+
+Expected: compile error — `percentFromMillivolts` is not declared in `Battery::` namespace.
+
+- [ ] **Step 3: Add inline `percentFromMillivolts` to battery.h**
+
+Replace `firmware/sensor-tag-wifi/src/battery.h` entirely with:
+
+```cpp
+#pragma once
+
+#include <cstdint>
+
+namespace Battery {
+
+constexpr uint16_t VBAT_FULL_MV  = 4200;
+constexpr uint16_t VBAT_EMPTY_MV = 3300;
+
+/// Read raw battery voltage via ADC, divider-corrected. Returns mV.
+/// Implemented in battery.cpp; requires Arduino runtime.
+uint16_t readMillivolts();
+
+/// Pure conversion: clamp + linear-interpolate mV to 0..100% Li-ion SOC.
+/// Inline so native unit tests can link without Arduino. The 4200/3300 mV
+/// endpoints assume 18650 Li-ion; see issue #10 for replacing the linear
+/// formula with a real discharge curve once vbat_mV telemetry is collected.
+inline uint8_t percentFromMillivolts(uint16_t mV) {
+    if (mV >= VBAT_FULL_MV)  return 100;
+    if (mV <= VBAT_EMPTY_MV) return 0;
+    return static_cast<uint8_t>(
+        (static_cast<float>(mV) - VBAT_EMPTY_MV) * 100.0f /
+        (VBAT_FULL_MV - VBAT_EMPTY_MV));
+}
+
+/// Convenience: composes readMillivolts() + percentFromMillivolts().
+uint8_t readPercent();
+
+}  // namespace Battery
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+cd firmware/sensor-tag-wifi && pio test -e native -f test_battery_math
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Run all native tests (regression check)**
+
+```
+cd firmware/sensor-tag-wifi && pio test -e native
+```
+
+Expected: 30 + 6 = 36 tests pass. (Existing 30 from payload/ota_*; 6 new from battery_math.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add firmware/sensor-tag-wifi/src/battery.h firmware/sensor-tag-wifi/test/test_battery_math/
+git commit -m "test(sensor-tag-wifi): add native tests for Battery::percentFromMillivolts
+
+Extracts the pure percent conversion as an inline header function so it
+can be unit-tested on the native env. Behavior unchanged."
+```
+
+---
+
+## Task 2: Refactor `battery.cpp` to expose `readMillivolts()`
+
+**Files:**
+- Modify: `firmware/sensor-tag-wifi/src/battery.cpp`
+
+- [ ] **Step 1: Replace battery.cpp with the refactored implementation**
+
+Replace `firmware/sensor-tag-wifi/src/battery.cpp` entirely with:
+
+```cpp
+#include "battery.h"
+#include "config.h"
+
+#include <Arduino.h>
+
+namespace {
+
+constexpr float DIVIDER_RATIO = 2.0f;   // 100k / 100k → 2:1
+constexpr uint8_t ADC_SAMPLES = 8;
+
+}  // anonymous namespace
+
+namespace Battery {
+
+uint16_t readMillivolts() {
+    uint32_t acc = 0;
+    for (uint8_t i = 0; i < ADC_SAMPLES; ++i) {
+        acc += analogReadMilliVolts(PIN_BATTERY_ADC);
+    }
+    float vbat = (acc / static_cast<float>(ADC_SAMPLES)) * DIVIDER_RATIO;
+    if (vbat < 0.0f) return 0;
+    if (vbat > UINT16_MAX) return UINT16_MAX;
+    return static_cast<uint16_t>(vbat);
+}
+
+uint8_t readPercent() {
+    return percentFromMillivolts(readMillivolts());
+}
+
+}  // namespace Battery
+```
+
+- [ ] **Step 2: Compile firmware to confirm Arduino target still builds**
+
+```
+cd firmware/sensor-tag-wifi && pio run -e xiao-c6-ds18b20
+```
+
+Expected: `SUCCESS`. No errors. (Pick `xiao-c6-ds18b20` — it's the deployed yard variant per ROUTER.)
+
+- [ ] **Step 3: Run all native tests (regression check)**
+
+```
+cd firmware/sensor-tag-wifi && pio test -e native
+```
+
+Expected: 36 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add firmware/sensor-tag-wifi/src/battery.cpp
+git commit -m "refactor(sensor-tag-wifi): split Battery::readPercent into mV + pure conv
+
+readMillivolts() does the ADC sweep; readPercent() composes it with the
+inline percentFromMillivolts(). Single ADC sweep, one source of truth
+for the conversion math, vbat_mV now exposable for telemetry."
+```
+
+---
+
+## Task 3: Extend `Reading` struct + `Payload::serialize()` signature (TDD)
+
+**Files:**
+- Modify: `firmware/sensor-tag-wifi/include/reading.h`
+- Modify: `firmware/sensor-tag-wifi/include/payload.h`
+- Modify: `firmware/sensor-tag-wifi/src/payload.cpp`
+- Modify: `firmware/sensor-tag-wifi/test/test_payload/test_payload.cpp`
+- Modify: `firmware/sensor-tag-wifi/src/mqtt_client.cpp` (call-site update — placeholder rssi=0 here, real value in Task 4)
+
+- [ ] **Step 1: Update `test_payload.cpp` to use the new signature and expected output**
+
+Replace `firmware/sensor-tag-wifi/test/test_payload/test_payload.cpp` entirely with:
+
+```cpp
+#include <unity.h>
+#include <cstring>
+#include <cmath>
+#include "reading.h"
+#include "payload.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_serialize_full_reading_with_humidity() {
+    Reading r {
+        .timestamp = 1712345678,
+        .temp1 = 22.4f,
+        .temp2 = 24.1f,
+        .humidity1 = 52.3f,
+        .humidity2 = 55.1f,
+        .vbat_mV = 3987,
+        .battery_pct = 87,
+    };
+    char buf[200];
+    int n = Payload::serialize("ab12cd34", "5423c04", -58, r, buf, sizeof(buf));
+    TEST_ASSERT_GREATER_THAN(0, n);
+    TEST_ASSERT_EQUAL_STRING(
+        "{\"id\":\"ab12cd34\",\"v\":\"5423c04\",\"t\":1712345678,"
+        "\"t1\":22.40,\"t2\":24.10,\"h1\":52.30,\"h2\":55.10,"
+        "\"vbat_mV\":3987,\"rssi\":-58,\"b\":87}",
+        buf);
+}
+
+void test_serialize_ds18b20_reading_omits_humidity() {
+    Reading r {
+        .timestamp = 1712345678,
+        .temp1 = 22.4f,
+        .temp2 = 24.1f,
+        .humidity1 = NAN,
+        .humidity2 = NAN,
+        .vbat_mV = 3987,
+        .battery_pct = 87,
+    };
+    char buf[200];
+    int n = Payload::serialize("ab12cd34", "5423c04", -58, r, buf, sizeof(buf));
+    TEST_ASSERT_GREATER_THAN(0, n);
+    TEST_ASSERT_EQUAL_STRING(
+        "{\"id\":\"ab12cd34\",\"v\":\"5423c04\",\"t\":1712345678,"
+        "\"t1\":22.40,\"t2\":24.10,\"vbat_mV\":3987,\"rssi\":-58,\"b\":87}",
+        buf);
+}
+
+void test_serialize_returns_negative_on_undersized_buffer() {
+    Reading r {
+        .timestamp = 1712345678,
+        .temp1 = 22.4f, .temp2 = 24.1f,
+        .humidity1 = 52.3f, .humidity2 = 55.1f,
+        .vbat_mV = 3987,
+        .battery_pct = 87,
+    };
+    char buf[8];
+    int n = Payload::serialize("ab12cd34", "5423c04", -58, r, buf, sizeof(buf));
+    TEST_ASSERT_LESS_THAN(0, n);
+}
+
+void test_serialize_emits_only_valid_humidity_channel() {
+    Reading r {
+        .timestamp = 1712345678,
+        .temp1 = 22.4f,
+        .temp2 = 24.1f,
+        .humidity1 = 52.3f,
+        .humidity2 = NAN,      // top SHT31 failed
+        .vbat_mV = 3987,
+        .battery_pct = 87,
+    };
+    char buf[200];
+    int n = Payload::serialize("ab12cd34", "5423c04", -58, r, buf, sizeof(buf));
+    TEST_ASSERT_GREATER_THAN(0, n);
+    TEST_ASSERT_EQUAL_STRING(
+        "{\"id\":\"ab12cd34\",\"v\":\"5423c04\",\"t\":1712345678,"
+        "\"t1\":22.40,\"t2\":24.10,\"h1\":52.30,"
+        "\"vbat_mV\":3987,\"rssi\":-58,\"b\":87}",
+        buf);
+}
+
+void test_serialize_emits_null_for_nan_temps() {
+    // Firmware must emit JSON `null` (not `nan`) so downstream JSON parsers
+    // (Telegraf json_v2, Swift JSONDecoder, etc.) don't reject the message.
+    Reading r {
+        .timestamp = 1712345678,
+        .temp1 = 21.50f,
+        .temp2 = NAN,           // external DS18B20 not wired
+        .humidity1 = NAN,
+        .humidity2 = NAN,
+        .vbat_mV = 0,
+        .battery_pct = 0,
+    };
+    char buf[200];
+    int n = Payload::serialize("c5fffe12", "5423c04", -58, r, buf, sizeof(buf));
+    TEST_ASSERT_GREATER_THAN(0, n);
+    TEST_ASSERT_EQUAL_STRING(
+        "{\"id\":\"c5fffe12\",\"v\":\"5423c04\",\"t\":1712345678,"
+        "\"t1\":21.50,\"t2\":null,\"vbat_mV\":0,\"rssi\":-58,\"b\":0}",
+        buf);
+}
+
+void test_serialize_emits_t_zero_when_timestamp_unset() {
+    // Readings buffered before the first NTP sync have timestamp=0. The payload
+    // must serialize this as "t":0 so Telegraf can apply the t=0 fallback rule
+    // and substitute the ingest time rather than silently emitting `nan` or
+    // omitting the field.
+    Reading r {
+        .timestamp = 0,
+        .temp1 = 20.00f,
+        .temp2 = 21.00f,
+        .humidity1 = NAN,
+        .humidity2 = NAN,
+        .vbat_mV = 3987,
+        .battery_pct = 50,
+    };
+    char buf[200];
+    int n = Payload::serialize("ab12cd34", "5423c04", -58, r, buf, sizeof(buf));
+    TEST_ASSERT_GREATER_THAN(0, n);
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"t\":0,"));
+}
+
+void test_serialize_with_unknown_version() {
+    // get_version.py falls back to the literal "unknown" when git describe
+    // fails. The payload must carry that string verbatim so the operator can
+    // still distinguish a no-git build from a real version.
+    Reading r {
+        .timestamp = 1712345678,
+        .temp1 = 22.4f,
+        .temp2 = 24.1f,
+        .humidity1 = NAN,
+        .humidity2 = NAN,
+        .vbat_mV = 3987,
+        .battery_pct = 87,
+    };
+    char buf[200];
+    int n = Payload::serialize("ab12cd34", "unknown", -58, r, buf, sizeof(buf));
+    TEST_ASSERT_GREATER_THAN(0, n);
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"v\":\"unknown\""));
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_serialize_full_reading_with_humidity);
+    RUN_TEST(test_serialize_ds18b20_reading_omits_humidity);
+    RUN_TEST(test_serialize_returns_negative_on_undersized_buffer);
+    RUN_TEST(test_serialize_emits_only_valid_humidity_channel);
+    RUN_TEST(test_serialize_emits_null_for_nan_temps);
+    RUN_TEST(test_serialize_emits_t_zero_when_timestamp_unset);
+    RUN_TEST(test_serialize_with_unknown_version);
+    return UNITY_END();
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail to compile**
+
+```
+cd firmware/sensor-tag-wifi && pio test -e native -f test_payload
+```
+
+Expected: compile errors — `vbat_mV` not a member of `Reading`, `serialize` signature mismatch.
+
+- [ ] **Step 3: Add `vbat_mV` to `Reading`**
+
+Replace `firmware/sensor-tag-wifi/include/reading.h` entirely with:
+
+```cpp
+#pragma once
+
+#include <cstdint>
+
+/// A single sensor sample. POD — safe to put in RTC_DATA_ATTR memory.
+///
+/// `t1`/`t2` are the two temperature channels (brood / top). `h1`/`h2` are the
+/// two humidity channels. NAN means the channel is unavailable (DS18B20 build,
+/// or a single SHT31 failing on a dual-sensor board) and is omitted from the
+/// serialized payload.
+///
+/// `vbat_mV` is the raw ADC reading (divider-corrected) at sample time, kept
+/// alongside `battery_pct` so downstream consumers can apply a better SOC
+/// curve later without a firmware change. See issue #10.
+struct Reading {
+    uint32_t timestamp;    // unix seconds
+    float    temp1;        // brood (°C)
+    float    temp2;        // top   (°C)
+    float    humidity1;    // brood (%RH) — NAN if unavailable
+    float    humidity2;    // top   (%RH) — NAN if unavailable
+    uint16_t vbat_mV;      // raw battery voltage at sample time
+    uint8_t  battery_pct;  // 0..100
+};
+```
+
+- [ ] **Step 4: Extend `payload.h` signature**
+
+Replace `firmware/sensor-tag-wifi/include/payload.h` entirely with:
+
+```cpp
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include "reading.h"
+
+namespace Payload {
+
+/// Serialize a reading into a JSON string.
+/// @param deviceId   8-char hex device ID (null-terminated)
+/// @param fwVersion  null-terminated firmware version string (from FIRMWARE_VERSION
+///                   build flag; `"unknown"` when git describe failed)
+/// @param rssi       WiFi RSSI captured post-connect at publish time, in dBm
+/// @param r          reading to serialize
+/// @param buf        output buffer
+/// @param bufLen     size of output buffer
+/// @return           number of bytes written (excluding null), or -1 on overflow
+int serialize(const char* deviceId,
+              const char* fwVersion,
+              int8_t      rssi,
+              const Reading& r,
+              char* buf, size_t bufLen);
+
+}  // namespace Payload
+```
+
+- [ ] **Step 5: Update `payload.cpp` to emit the new fields**
+
+Replace `firmware/sensor-tag-wifi/src/payload.cpp` entirely with:
+
+```cpp
+#include "payload.h"
+
+#include <cmath>
+#include <cstdarg>
+#include <cstdio>
+
+namespace Payload {
+
+/// Append a formatted fragment to buf, returning true on success. Fails if the
+/// buffer would overflow.
+static bool appendf(char*& p, char* end, const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(p, end - p, fmt, ap);
+    va_end(ap);
+    if (n < 0 || n >= end - p) return false;
+    p += n;
+    return true;
+}
+
+/// Serialize a float field as either a number (`%.2f`) or JSON `null` when NaN.
+/// `%.2f` on NaN prints `nan`, which is not valid JSON and breaks downstream
+/// parsers (Telegraf json_v2, Swift JSONDecoder, PostgreSQL json type).
+static bool appendNumOrNull(char*& p, char* end, const char* key, float v) {
+    if (std::isnan(v)) return appendf(p, end, ",\"%s\":null", key);
+    return appendf(p, end, ",\"%s\":%.2f", key, v);
+}
+
+int serialize(const char* deviceId,
+              const char* fwVersion,
+              int8_t      rssi,
+              const Reading& r,
+              char* buf, size_t bufLen) {
+    if (bufLen == 0) return -1;
+    char* p   = buf;
+    char* end = buf + bufLen;
+
+    if (!appendf(p, end, "{\"id\":\"%s\",\"v\":\"%s\",\"t\":%lu",
+                 deviceId, fwVersion,
+                 static_cast<unsigned long>(r.timestamp))) return -1;
+    if (!appendNumOrNull(p, end, "t1", r.temp1)) return -1;
+    if (!appendNumOrNull(p, end, "t2", r.temp2)) return -1;
+    if (!std::isnan(r.humidity1) && !appendf(p, end, ",\"h1\":%.2f", r.humidity1)) return -1;
+    if (!std::isnan(r.humidity2) && !appendf(p, end, ",\"h2\":%.2f", r.humidity2)) return -1;
+    if (!appendf(p, end, ",\"vbat_mV\":%u,\"rssi\":%d,\"b\":%u}",
+                 static_cast<unsigned>(r.vbat_mV),
+                 static_cast<int>(rssi),
+                 static_cast<unsigned>(r.battery_pct))) return -1;
+
+    return static_cast<int>(p - buf);
+}
+
+}  // namespace Payload
+```
+
+- [ ] **Step 6: Run native tests — they should pass now**
+
+```
+cd firmware/sensor-tag-wifi && pio test -e native -f test_payload
+```
+
+Expected: 7 payload tests pass.
+
+- [ ] **Step 7: Compile firmware to surface the mqtt_client.cpp call-site mismatch**
+
+```
+cd firmware/sensor-tag-wifi && pio run -e xiao-c6-ds18b20
+```
+
+Expected: compile error in `mqtt_client.cpp` — `Payload::serialize` is now called with the wrong number of arguments.
+
+- [ ] **Step 8: Update the `mqtt_client.cpp` call site (placeholder rssi=0; real wiring in Task 4)**
+
+In `firmware/sensor-tag-wifi/src/mqtt_client.cpp`, find the line (currently around line 63):
+
+```cpp
+    int n = Payload::serialize(deviceId, r, payload, sizeof(payload));
+```
+
+Replace with:
+
+```cpp
+    // RSSI captured post-connect — wired in next task; placeholder 0 here
+    // makes the call site type-check during the payload-shape rollout.
+    int n = Payload::serialize(deviceId, FIRMWARE_VERSION, 0, r, payload, sizeof(payload));
+```
+
+Also at the top of `mqtt_client.cpp`, ensure the FIRMWARE_VERSION macro fallback is present (mirrors the pattern in [src/ota.cpp:17-18](firmware/sensor-tag-wifi/src/ota.cpp#L17-L18)). If not already there, add immediately after the existing `#include` block:
+
+```cpp
+#ifndef FIRMWARE_VERSION
+#define FIRMWARE_VERSION "unknown"
+#endif
+```
+
+- [ ] **Step 9: Compile firmware again — should succeed**
+
+```
+cd firmware/sensor-tag-wifi && pio run -e xiao-c6-ds18b20
+```
+
+Expected: `SUCCESS`.
+
+- [ ] **Step 10: Run full native test suite (regression)**
+
+```
+cd firmware/sensor-tag-wifi && pio test -e native
+```
+
+Expected: 37 tests pass (30 prior + 6 battery_math + 1 new payload-unknown-version, minus 0 — original 6 payload tests still pass).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add firmware/sensor-tag-wifi/include/reading.h \
+        firmware/sensor-tag-wifi/include/payload.h \
+        firmware/sensor-tag-wifi/src/payload.cpp \
+        firmware/sensor-tag-wifi/src/mqtt_client.cpp \
+        firmware/sensor-tag-wifi/test/test_payload/test_payload.cpp
+git commit -m "feat(sensor-tag-wifi): add v, vbat_mV, rssi to reading payload
+
+v: firmware version string (from get_version.py, 'unknown' fallback)
+vbat_mV: raw ADC voltage at sample time, persists in RTC ring buffer
+rssi: WiFi RSSI passed by caller at publish time (wired in next commit)
+
+Telegraf parser update + main.cpp/mqtt_client.cpp wiring follow."
+```
+
+---
+
+## Task 4: Wire `vbat_mV` at sample time and capture RSSI at publish time
+
+**Files:**
+- Modify: `firmware/sensor-tag-wifi/src/main.cpp`
+- Modify: `firmware/sensor-tag-wifi/src/mqtt_client.cpp`
+
+- [ ] **Step 1: Populate `r.vbat_mV` in `sampleAndEnqueue`**
+
+In `firmware/sensor-tag-wifi/src/main.cpp`, find the `sampleAndEnqueue()` function (around line 87). Locate these two lines:
+
+```cpp
+    r.battery_pct = Battery::readPercent();
+    lastBatteryPct = r.battery_pct;
+```
+
+Replace with:
+
+```cpp
+    r.vbat_mV     = Battery::readMillivolts();
+    r.battery_pct = Battery::percentFromMillivolts(r.vbat_mV);
+    lastBatteryPct = r.battery_pct;
+```
+
+Also update the diagnostic Serial.printf below it (currently logs `b=%u`) to include the raw mV. Find:
+
+```cpp
+    Serial.printf("[MAIN] sample t1=%.2f t2=%.2f h1=%.2f h2=%.2f b=%u buffered=%u\n",
+                  r.temp1, r.temp2, r.humidity1, r.humidity2, r.battery_pct,
+                  RingBuffer::size());
+```
+
+Replace with:
+
+```cpp
+    Serial.printf("[MAIN] sample t1=%.2f t2=%.2f h1=%.2f h2=%.2f vbat=%umV b=%u buffered=%u\n",
+                  r.temp1, r.temp2, r.humidity1, r.humidity2,
+                  r.vbat_mV, r.battery_pct, RingBuffer::size());
+```
+
+- [ ] **Step 2: Capture `WiFi.RSSI()` and pass it through the publish path in `mqtt_client.cpp`**
+
+Open `firmware/sensor-tag-wifi/src/mqtt_client.cpp`. Find the function that publishes a single reading (the one containing the `Payload::serialize` call updated in Task 3). The structure is roughly:
+
+```cpp
+bool publish(const char* deviceId, const Reading& r) {
+    char topic[64];
+    snprintf(topic, sizeof(topic), "%s%s/reading", MQTT_TOPIC_PREFIX, deviceId);
+
+    char payload[PAYLOAD_MAX_LEN];
+    int n = Payload::serialize(deviceId, FIRMWARE_VERSION, 0, r, payload, sizeof(payload));
+    ...
+}
+```
+
+Make `publish()` accept the rssi value as a parameter rather than hard-coding 0. Update the function signature and forward it to `serialize`:
+
+```cpp
+bool publish(const char* deviceId, const Reading& r, int8_t rssi) {
+    char topic[64];
+    snprintf(topic, sizeof(topic), "%s%s/reading", MQTT_TOPIC_PREFIX, deviceId);
+
+    char payload[PAYLOAD_MAX_LEN];
+    int n = Payload::serialize(deviceId, FIRMWARE_VERSION, rssi, r, payload, sizeof(payload));
+    ...
+}
+```
+
+Update the matching declaration in `mqtt_client.h` (or wherever `publish` is declared — likely `mqtt_client.h` next to the cpp). Open the header and update the signature to match:
+
+```cpp
+bool publish(const char* deviceId, const Reading& r, int8_t rssi);
+```
+
+- [ ] **Step 3: Capture RSSI in `uploadAndCheckOta` and pass it through to `publish()`**
+
+The drain loop lives in [src/main.cpp::uploadAndCheckOta](firmware/sensor-tag-wifi/src/main.cpp), not `mqtt_client.cpp`. RSSI must be captured AFTER `WifiManager::connect()` succeeds and BEFORE `MqttClient::publish()` is called.
+
+In `firmware/sensor-tag-wifi/src/main.cpp`, find the existing `uploadAndCheckOta()` function. Locate this block:
+
+```cpp
+    if (RingBuffer::size() > 0) {
+        if (MqttClient::connect(deviceId)) {
+            uint8_t sent = 0;
+            while (RingBuffer::size() > 0) {
+                Reading r;
+                if (!RingBuffer::peekOldest(r)) break;
+                if (!MqttClient::publish(deviceId, r)) break;
+                RingBuffer::popOldest();
+                sent++;
+                Ota::onPublishSuccess();
+            }
+            Serial.printf("[MAIN] sent %u / remaining %u\n", sent, RingBuffer::size());
+            MqttClient::disconnect();
+        } else {
+            Serial.println("[MAIN] no mqtt — keeping buffer");
+        }
+    }
+```
+
+Replace with (capture RSSI right after MQTT connect succeeds, then forward to each publish):
+
+```cpp
+    if (RingBuffer::size() > 0) {
+        if (MqttClient::connect(deviceId)) {
+            int8_t sessionRssi = static_cast<int8_t>(WiFi.RSSI());
+            Serial.printf("[MAIN] mqtt connected rssi=%d dBm\n", sessionRssi);
+            uint8_t sent = 0;
+            while (RingBuffer::size() > 0) {
+                Reading r;
+                if (!RingBuffer::peekOldest(r)) break;
+                if (!MqttClient::publish(deviceId, r, sessionRssi)) break;
+                RingBuffer::popOldest();
+                sent++;
+                Ota::onPublishSuccess();
+            }
+            Serial.printf("[MAIN] sent %u / remaining %u\n", sent, RingBuffer::size());
+            MqttClient::disconnect();
+        } else {
+            Serial.println("[MAIN] no mqtt — keeping buffer");
+        }
+    }
+```
+
+If `WiFi.RSSI()` fails to compile, add `#include <WiFi.h>` near the top of `main.cpp` (likely pulled in transitively via `wifi_manager.h`, but add explicitly if needed).
+
+This is the only `MqttClient::publish` call site in the codebase. After this step, the placeholder rssi=0 from Task 3 Step 8 is gone (the value now flows: `uploadAndCheckOta` → `MqttClient::publish` → `Payload::serialize`).
+
+- [ ] **Step 4: Compile firmware to confirm Arduino target builds**
+
+```
+cd firmware/sensor-tag-wifi && pio run -e xiao-c6-ds18b20
+```
+
+Expected: `SUCCESS`.
+
+- [ ] **Step 5: Compile the SHT31 variant too (it shares the same files)**
+
+```
+cd firmware/sensor-tag-wifi && pio run -e xiao-c6-sht31
+```
+
+Expected: `SUCCESS`.
+
+- [ ] **Step 6: Compile the S3-Zero variant**
+
+```
+cd firmware/sensor-tag-wifi && pio run -e waveshare-s3zero-ds18b20
+```
+
+Expected: `SUCCESS`.
+
+- [ ] **Step 7: Run full native test suite (regression)**
+
+```
+cd firmware/sensor-tag-wifi && pio test -e native
+```
+
+Expected: 37 tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add firmware/sensor-tag-wifi/src/main.cpp \
+        firmware/sensor-tag-wifi/src/mqtt_client.cpp \
+        firmware/sensor-tag-wifi/src/mqtt_client.h
+git commit -m "feat(sensor-tag-wifi): wire vbat_mV at sample time, capture rssi at publish
+
+Sample loop populates Reading.vbat_mV from Battery::readMillivolts and
+derives battery_pct from the same value (one ADC sweep per sample).
+Drain loop captures WiFi.RSSI() once post-connect and forwards it to
+every publish() call in the session."
+```
+
+---
+
+## Task 5: Update Telegraf parser config (canonical mirror)
+
+**Files:**
+- Modify: `deploy/tsdb/telegraf-combsense.conf`
+
+- [ ] **Step 1: Add three new field blocks to the json_v2 parser**
+
+Open `deploy/tsdb/telegraf-combsense.conf`. Find the existing block (lines ~31-35):
+
+```toml
+    [[inputs.mqtt_consumer.json_v2.field]]
+      path = "t"
+      rename = "sensor_ts"
+      type = "int"
+      optional = true
+```
+
+Immediately after that closing block, insert three new blocks:
+
+```toml
+    [[inputs.mqtt_consumer.json_v2.field]]
+      path = "v"
+      rename = "fw_version"
+      type = "string"
+      optional = true
+    [[inputs.mqtt_consumer.json_v2.field]]
+      path = "vbat_mV"
+      type = "int"
+      optional = true
+    [[inputs.mqtt_consumer.json_v2.field]]
+      path = "rssi"
+      type = "int"
+      optional = true
+```
+
+All three are `optional = true` so older sensor-tag-wifi builds (pre-upgrade) continue to parse without errors during the rollout window.
+
+- [ ] **Step 2: Commit the canonical-mirror update**
+
+```bash
+git add deploy/tsdb/telegraf-combsense.conf
+git commit -m "feat(tsdb): parse v/vbat_mV/rssi from sensor-tag-wifi reading payload
+
+Adds three optional json_v2 fields. fw_version is captured as a string
+field (not a tag) to avoid Influx series-cardinality blow-up on every
+OTA. All three are optional to allow rollout overlap with un-upgraded
+tags."
+```
+
+---
+
+## Task 6: End-to-end verification (bench + LXC deploy)
+
+This task is operational, not code. Each step validates the changes in the live pipeline.
+
+- [ ] **Step 1: Flash the SHT31 yard tag c5fffe12 with the new build**
+
+```
+cd firmware/sensor-tag-wifi && pio run -e xiao-c6-sht31 --target upload
+```
+
+Expected: upload succeeds. (Bench-tag the yard unit if it's at home; otherwise pick a bench tag.)
+
+- [ ] **Step 2: Monitor serial output, confirm new payload shape and one publish cycle**
+
+```
+cd firmware/sensor-tag-wifi && pio device monitor
+```
+
+Wait for one wake → publish cycle. Expected log lines:
+- `[MAIN] combsense sensor-tag-wifi id=<8-hex> version=<sha-or-tag>`
+- `[MAIN] sample t1=... t2=... h1=... h2=... vbat=<n>mV b=<n> buffered=...`
+- `[MQTT] connected rssi=<-100..-30> dBm`
+- A `PUBLISH` log line containing the new JSON shape with `"v"`, `"vbat_mV"`, `"rssi"` fields.
+
+If `vbat_mV` reads as `0`, you're on USB without a cell attached — that's expected per memory `project_sensor_tag_wifi_battery_gate.md`. Attach a cell to exercise the full path.
+
+- [ ] **Step 3: Deploy the Telegraf config to combsense-tsdb LXC**
+
+```bash
+scp deploy/tsdb/telegraf-combsense.conf root@192.168.1.19:/etc/telegraf/telegraf.conf
+ssh root@192.168.1.19 'systemctl restart telegraf && journalctl -u telegraf -n 50 --no-pager'
+```
+
+Expected: telegraf restarts cleanly, no parse errors in the last 50 log lines.
+
+- [ ] **Step 4: Wait for the next bench-tag publish, verify Telegraf parses it**
+
+```bash
+ssh root@192.168.1.19 'journalctl -u telegraf -f --no-pager'
+```
+
+Wait for one publish cycle (≤5 min default cadence). Expected: no `json_v2: failed to parse` or similar errors.
+
+- [ ] **Step 5: Confirm Influx received the new fields**
+
+```bash
+ssh root@192.168.1.19 'source /root/.combsense-tsdb-creds && \
+  influx query "from(bucket:\"combsense\") |> range(start:-15m) |> filter(fn:(r) => r._measurement == \"sensor_reading\") |> filter(fn:(r) => r._field == \"fw_version\" or r._field == \"vbat_mV\" or r._field == \"rssi\") |> last()" \
+  --org combsense --token \$admin_token'
+```
+
+Expected: three rows returned, one per new field, with the bench tag's `sensor_id`. `fw_version` value matches the build sha you flashed.
+
+- [ ] **Step 6: Update ROUTER**
+
+In `.mex/ROUTER.md`, find the sensor-tag-wifi section bullet about native test counts. Change:
+
+```
+  - Native Unity tests: 30 passing across payload (6), OTA manifest parser (9), OTA decision (6), OTA validate-on-boot (4), sha256 streamer (5)
+```
+
+to:
+
+```
+  - Native Unity tests: 37 passing across payload (7), battery math (6), OTA manifest parser (9), OTA decision (6), OTA validate-on-boot (4), sha256 streamer (5)
+```
+
+Add one bullet under the sensor-tag-wifi section:
+
+```
+  - **Fleet visibility:** reading payload self-identifies build (`v`), and carries raw battery mV (`vbat_mV`) plus post-connect WiFi RSSI (`rssi`) for diagnostics. Telegraf parses all three as Influx fields (`fw_version`, `vbat_mV`, `rssi`).
+```
+
+Update the `last_updated` line at the top.
+
+- [ ] **Step 7: Commit ROUTER update**
+
+```bash
+git add .mex/ROUTER.md
+git commit -m "docs(mex): record fleet-visibility payload fields and updated test count"
+```
+
+- [ ] **Step 8: Open PR from `dev` to `main`**
+
+```bash
+git push origin dev
+gh pr create --base main --head dev --title "sensor-tag-wifi: fleet visibility (v + vbat_mV + rssi)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds firmware version (`v`), raw battery voltage (`vbat_mV`), and post-connect WiFi RSSI (`rssi`) to every reading payload.
+- Refactors `Battery::readPercent()` into pure `percentFromMillivolts()` (native-testable) + Arduino-dependent `readMillivolts()`.
+- Telegraf parser captures all three as Influx fields (string for fw_version → no series-cardinality churn on OTA).
+- Heartbeat work deferred to issue #11 with full A/B/C analysis.
+
+## Test plan
+- [x] `pio test -e native` — 37 tests pass (was 30; +6 battery_math, +1 payload-unknown-version)
+- [x] `pio run -e xiao-c6-sht31` — compiles
+- [x] `pio run -e xiao-c6-ds18b20` — compiles
+- [x] `pio run -e waveshare-s3zero-ds18b20` — compiles
+- [x] Bench tag publishes payload with new fields, Influx records `fw_version`, `vbat_mV`, `rssi`
+- [x] Telegraf restart on combsense-tsdb LXC clean, no parse errors
+
+## Spec / plan
+- Spec: `docs/superpowers/specs/2026-04-25-sensor-tag-wifi-fleet-visibility-design.md`
+- Plan: `docs/superpowers/plans/2026-04-25-sensor-tag-wifi-fleet-visibility.md`
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** every item in the spec has a corresponding task. Battery refactor → Tasks 1-2. Reading struct + serialize signature + tests → Task 3. main.cpp/mqtt_client.cpp wiring → Task 4. Telegraf → Task 5. Verification (native tests, three compile envs, bench, deploy, Influx confirm, ROUTER update) → Task 6.
+- **Type consistency:** `serialize` signature is the same in `payload.h`, `payload.cpp`, all 7 test fixtures, and the `mqtt_client.cpp` call site. `vbat_mV` declared as `uint16_t` in `Reading`, used as `%u` (`unsigned`) in `payload.cpp` via cast. `rssi` declared `int8_t` in the signature, cast to `int` for `%d` in `payload.cpp`. `Battery::readMillivolts` returns `uint16_t`, consumed unchanged into `Reading::vbat_mV`.
+- **Field positions in `Reading`:** `vbat_mV` placed between `humidity2` and `battery_pct`. C++20 designated initializers must be in declaration order, so all 7 test fixtures keep `.vbat_mV` between `.humidity2` and `.battery_pct`. RTC layout grows by 2 bytes (acceptable: `RTC_DATA_ATTR` budget is many KB).
+- **No placeholders:** all code shown verbatim. No "similar to Task N", no TBD. The only deliberately-temporary value (placeholder rssi=0 in Task 3 Step 8) is replaced in Task 4 Step 3 — flagged inline as a placeholder with a comment.

--- a/docs/superpowers/specs/2026-04-24-sensor-tag-wifi-ota-design.md
+++ b/docs/superpowers/specs/2026-04-24-sensor-tag-wifi-ota-design.md
@@ -1,0 +1,323 @@
+# Sensor-Tag-Wifi OTA — Design Spec
+
+**Date:** 2026-04-24
+**Status:** Approved, ready for plan
+**Repo touch points:** `firmware/sensor-tag-wifi/`, `deploy/web/`, `tools/provision_tag.py`
+
+## Goal
+
+Give the home-yard sensor-tag-wifi (XIAO ESP32-C6) **HTTP-pull OTA** so a device deployed at a beehive can be updated without physical access.
+
+The device wakes every ~5 min, reads sensors, publishes MQTT, and deep-sleeps. After the publish, it fetches a small JSON manifest from a local nginx host; if the manifest's version differs from the compiled-in version, it streams a new firmware binary into the inactive OTA partition, verifies SHA-256, and reboots into it. The new firmware proves itself by completing one full publish cycle; otherwise the bootloader rolls back automatically.
+
+## Non-Goals
+
+- OTA for the cellular collector or hive-node (already implemented separately).
+- Public/internet-exposed firmware host. This is LAN-only.
+- Cryptographic signing. SHA-256 in the manifest covers integrity; signing is deferred until/if firmware ever leaves the LAN.
+- Per-device targeting (rolling subsets, canary deploys). Manifest is per-variant; all devices of that variant track it.
+
+## Architecture
+
+**Per-wake flow:**
+
+```
+deep sleep
+  └─ wake
+      ├─ Ota::validateOnBoot()      ← detect rollback, update NVS state
+      ├─ sample sensor
+      ├─ wifi connect
+      ├─ mqtt connect + publish reading
+      │     └─ if publish ok: Ota::onPublishSuccess()
+      │           └─ if PENDING_VERIFY: mark valid, clear NVS state
+      ├─ Ota::checkAndApply(batteryPct)
+      │     ├─ GET manifest.json
+      │     ├─ skip if manifest.version == FIRMWARE_VERSION
+      │     ├─ skip if manifest.version == NVS.failed
+      │     ├─ skip if batteryPct < OTA_BATTERY_FLOOR_PCT (20)
+      │     ├─ stream-download bin → inactive partition; running SHA-256
+      │     ├─ verify SHA-256 == manifest.sha256 (else abort)
+      │     ├─ esp_ota_set_boot_partition(inactive)
+      │     ├─ NVS.attempted = manifest.version
+      │     └─ esp_restart()
+      └─ deep sleep
+```
+
+**Invariants:**
+
+1. Reading is published *before* the OTA check — never lose a sample to an OTA download.
+2. New firmware is only marked valid after a successful publish — bootloader rolls back if `mark_valid` never fires.
+3. After a rollback, the old firmware refuses to re-attempt the same version until the manifest moves.
+4. Manifest is the single source of truth: change version → all devices in that variant move; revert → they revert.
+
+## Components
+
+### New files
+
+`firmware/sensor-tag-wifi/src/ota.{h,cpp}`
+Thin wrapper around `esp_http_client_*` + `esp_ota_*`. Public API:
+
+```cpp
+namespace Ota {
+    void validateOnBoot();
+    void onPublishSuccess();
+    void checkAndApply(uint8_t batteryPct);
+}
+```
+
+All decision logic delegated to pure functions in `ota_decision.cpp` for native testability. `ota.cpp` is the side-effecting shell.
+
+`firmware/sensor-tag-wifi/src/ota_manifest.{h,cpp}`
+Pure JSON parser. Fixed-size, no allocations beyond the `Manifest` struct.
+
+```cpp
+struct Manifest {
+    char version[32];
+    char url[256];
+    char sha256[65];   // 64 hex + null
+    size_t size;
+};
+bool parseManifest(const char* json, size_t len, Manifest& out);
+```
+
+`firmware/sensor-tag-wifi/src/ota_decision.{h,cpp}`
+Pure decision functions:
+
+```cpp
+bool shouldApply(const char* current, const char* manifest, const char* failed, uint8_t batteryPct);
+
+enum class ValidateAction { NoOp, ClearAttempted, RecordFailed };
+ValidateAction validateOnBootAction(const char* firmwareVersion, const char* attempted, bool isPendingVerify);
+```
+
+`firmware/sensor-tag-wifi/src/ota_state.{h,cpp}`
+Thin `Preferences` adapter. Get/set `attempted`, `failed` strings under namespace `ota`. Abstract behind a header so native tests can substitute an in-memory store.
+
+`firmware/sensor-tag-wifi/include/config.h` *(create)*
+Constants:
+
+```cpp
+constexpr const char* OTA_DEFAULT_HOST = "192.168.1.61";
+constexpr uint8_t     OTA_BATTERY_FLOOR_PCT = 20;
+constexpr uint32_t    OTA_HTTP_TIMEOUT_MS  = 30000;
+```
+
+URLs are built at runtime from `Preferences::getString("ota_host", OTA_DEFAULT_HOST)` + the compile-time `OTA_VARIANT` macro.
+
+### New tests
+
+`firmware/sensor-tag-wifi/test/test_ota_manifest/test_ota_manifest.cpp`
+`firmware/sensor-tag-wifi/test/test_ota_decision/test_ota_decision.cpp`
+`firmware/sensor-tag-wifi/test/test_ota_validation/test_ota_validation.cpp`
+`firmware/sensor-tag-wifi/test/test_ota_sha256/test_ota_sha256.cpp`
+
+### Modified files
+
+`firmware/sensor-tag-wifi/partitions_tag.csv` — replace single 3 MB `app0` with dual 1.5 MB OTA slots:
+
+```
+nvs       data nvs    0x9000   0x5000
+otadata   data ota    0xE000   0x2000
+app0      app  ota_0  0x10000  0x180000
+app1      app  ota_1  0x190000 0x180000
+spiffs    data spiffs 0x310000 0xF0000
+```
+
+Total: 0x400000 (4 MB). Current binary is ~1.0 MB → 33% headroom per slot.
+
+`firmware/sensor-tag-wifi/platformio.ini` — for both `xiao-c6-sht31` and `xiao-c6-ds18b20` envs:
+
+- `extra_scripts = pre:get_version.py` — script writes a `-DFIRMWARE_VERSION=\"...\"` build flag from `git describe --tags --always --dirty`.
+- Add `-DOTA_VARIANT=\"sht31\"` and `-DOTA_VARIANT=\"ds18b20\"` in respective env build flags.
+
+`firmware/sensor-tag-wifi/get_version.py` *(new)* — PIO pre-script that injects `FIRMWARE_VERSION`.
+
+`firmware/sensor-tag-wifi/src/main.cpp`:
+
+- `Ota::validateOnBoot()` early in `setup()`.
+- `Ota::onPublishSuccess()` immediately after a successful `mqtt.publish()` ack.
+- `Ota::checkAndApply(batteryPct)` after publish, before `esp_deep_sleep_start()`.
+
+`firmware/sensor-tag-wifi/src/serial_console.{h,cpp}` — extend to accept `set ota_host <ip>` command, persisted via `Preferences`.
+
+`tools/provision_tag.py` — gain `--ota-host` flag that drives the same serial command.
+
+## State machine + NVS schema
+
+**NVS namespace:** `ota`
+
+| Key | Type | Lifetime |
+|---|---|---|
+| `attempted` | string | Set just before `esp_restart` after `set_boot_partition`. Cleared after `mark_app_valid_cancel_rollback`. |
+| `failed` | string | Set when `validateOnBoot` detects a rollback. Cleared after a different version successfully validates. |
+
+**Order of operations during apply** (matters for power-loss safety):
+
+```
+1. fetch manifest, parse
+2. apply gates (same/failed/battery)
+3. esp_ota_begin → stream download → SHA-256 verify
+4. esp_ota_end
+5. esp_ota_set_boot_partition(inactive)
+6. NVS.attempted = manifest.version
+7. esp_restart()
+```
+
+Power loss between 5 and 6 is safe: device boots the new firmware on restore; NVS.attempted is empty, so `validateOnBoot` does nothing; the new firmware still must publish to mark itself valid.
+
+**`validateOnBootAction` truth table:**
+
+| `attempted` (NVS) | `firmwareVersion` (compiled) | `PENDING_VERIFY` | Action |
+|---|---|---|---|
+| empty | any | any | NoOp |
+| `vX` | `vX` | true | NoOp (let `onPublishSuccess` clear) |
+| `vX` | `vX` | false | ClearAttempted (we already validated; clean up) |
+| `vX` | `vY` (≠ vX) | any | RecordFailed (rollback occurred) |
+
+**`shouldApply` truth table:**
+
+| `current` | `manifest` | `failed` | `battery` | Result |
+|---|---|---|---|---|
+| `vX` | `vX` | * | * | false (already up to date) |
+| `vX` | `vY` | `vY` | * | false (known bad) |
+| `vX` | `vY` | * | <20 | false (low battery) |
+| `vX` | `vY` (≠ vX, ≠ failed) | * | ≥20 | true |
+
+## Failure handling matrix
+
+| Failure | Behavior | Side effect |
+|---|---|---|
+| Manifest GET fails (timeout / 404 / parse error) | Log, continue to sleep | None |
+| `esp_ota_begin` fails | Log, continue | None |
+| Download stream read fails | `esp_ota_abort`, log, continue | None — partial write discarded |
+| SHA-256 mismatch | `esp_ota_abort`, log, continue | None — *don't* mark version `failed` (could be transient corruption) |
+| Power loss during steps 1-4 | Old firmware still active on next boot | None |
+| Power loss between 5 and 6 | New firmware boots, NVS empty; standard PENDING_VERIFY path | Slight risk of false validation if new firmware happens to publish ok despite a real bug — bounded by validation gate |
+| New firmware can't publish | Watchdog/reset → bootloader rolls back | Old firmware records `failed = manifest.version`, skips that version henceforth |
+| Manifest forever serves a SHA that no binary matches | Device GETs manifest, attempts download, aborts on mismatch, retries every wake | Operator-visible via nginx 200s + serial log; fix on server |
+
+## Server side
+
+**Filesystem on combsense-web LXC (192.168.1.61):**
+
+```
+/var/www/combsense-firmware/
+└── sensor-tag-wifi/
+    ├── sht31/
+    │   ├── manifest.json
+    │   └── v0.2.0/firmware.bin
+    └── ds18b20/
+        ├── manifest.json
+        └── v0.2.0/firmware.bin
+```
+
+Versioned subdirs preserve old binaries → instant rollback by editing `manifest.json` to point at an older `firmware.bin`. Old dirs prunable manually.
+
+**Manifest shape:**
+
+```json
+{
+  "version": "v0.2.0",
+  "url": "http://192.168.1.61/firmware/sensor-tag-wifi/ds18b20/v0.2.0/firmware.bin",
+  "sha256": "abc123…",
+  "size": 1046912
+}
+```
+
+**nginx fragment** — added to the `:80` server in `deploy/web/nginx/combsense-web.conf`, *before* the catch-all HTTPS redirect:
+
+```nginx
+location /firmware/ {
+    alias /var/www/combsense-firmware/;
+    autoindex off;
+    default_type application/octet-stream;
+    types { application/json json; application/octet-stream bin; }
+
+    allow 192.168.0.0/16;
+    deny all;
+}
+```
+
+HTTP, not HTTPS: integrity is the SHA-256 in the manifest. The `allow` block is defense-in-depth against accidental WAN exposure.
+
+**Publish workflow — `deploy/web/publish-firmware.sh`** (new):
+
+Runs from the developer machine (not the LXC). Must be invoked from the repo root or chdir into `firmware/sensor-tag-wifi/`. Requires SSH key auth to `natas@192.168.1.61` with passwordless sudo (already established).
+
+```
+publish-firmware.sh <variant>
+  1. VERSION=$(git describe --tags --always)
+  2. pio run -e xiao-c6-<variant>
+  3. SHA + SIZE of .pio/build/xiao-c6-<variant>/firmware.bin
+  4. scp bin → /tmp/firmware.bin on LXC
+  5. ssh: sudo mv into /var/www/combsense-firmware/sensor-tag-wifi/<variant>/<version>/firmware.bin
+  6. write manifest.json locally with version/url/sha256/size
+  7. scp manifest → /tmp; ssh: sudo mv into /var/www/combsense-firmware/sensor-tag-wifi/<variant>/manifest.json
+```
+
+Atomic via `mv` into final paths; never a partial-state window where the manifest references a missing binary.
+
+**Cleanup policy:** old versioned subdirs are *not* auto-pruned. Manual housekeeping when storage matters (e.g., `rm -rf v0.1.x`). Acceptable for the expected publish cadence.
+
+**One-time LXC setup (in implementation plan, not the script):**
+
+- `mkdir -p /var/www/combsense-firmware/sensor-tag-wifi/{sht31,ds18b20}` (root-owned, world-readable)
+- Add nginx fragment to `combsense-web.conf`, `nginx -t`, `systemctl reload nginx`
+
+## Auth and integrity
+
+| Concern | Mitigation |
+|---|---|
+| Bit-flip during download | SHA-256 in manifest, verified before `esp_ota_set_boot_partition` |
+| Accidental WAN exposure | `allow 192.168.0.0/16; deny all;` in nginx |
+| LAN-attached attacker injecting binaries | Out of scope for v1; documented as a follow-up if firmware host is ever exposed beyond LAN |
+| Server compromise | Out of scope (root on the LXC = bigger problems than OTA) |
+
+No TLS — without cert pinning + a CA bundle on the device, HTTPS would just be skip-verify TLS, which is pretend-security. Skip the complexity.
+
+## Testing
+
+### Native unit tests (`pio test -e native`, Unity)
+
+| Test | Coverage |
+|---|---|
+| `test_ota_manifest` | Valid JSON, missing fields, malformed JSON, oversize input → struct fields populate or `false` |
+| `test_ota_decision` | All paths through `shouldApply`: same version, failed version, low battery, valid update |
+| `test_ota_validation` | All 4 rows of the `validateOnBootAction` truth table |
+| `test_ota_sha256` | Streaming SHA-256 verifier produces known fixture hash |
+
+All decision logic is in pure functions → 100% native coverage of the state machine without hardware.
+
+### Hardware smoke tests (manual, post-deploy)
+
+| Scenario | How to provoke | Pass condition |
+|---|---|---|
+| Happy-path upgrade | Bump tag, run `publish-firmware.sh ds18b20` | New version appears in Influx at next wake; serial log shows `download → reboot → validate` |
+| Same-version no-op | Republish same tag | Only manifest GETs in nginx access log; no download |
+| SHA-256 mismatch | Corrupt 1 byte of `firmware.bin` on LXC | Device aborts, continues publishing; no boot-partition change |
+| Failed-publish rollback | Push a binary that hard-fails `mqtt.publish()` | One failed boot, bootloader rolls back, NVS records `failed`, subsequent wakes skip |
+| Battery floor | Set `OTA_BATTERY_FLOOR_PCT=99` in a test build | Skip download even though manifest version differs |
+
+### Diagnostic logging
+
+Every OTA decision emits a single line over USB-CDC serial:
+
+```
+[OTA] check version=v0.2.0 manifest=v0.2.0 failed= → skip(same)
+[OTA] check version=v0.2.0 manifest=v0.3.0 failed= battery=85 → download
+[OTA] download bytes=1046912 sha256_ok=true → reboot
+[OTA] validate result=rollback_detected attempted=v0.3.0
+```
+
+Smoke tests become self-documenting — tail serial during the test, paste lines into the runbook.
+
+## Open questions
+
+None. All design decisions resolved during brainstorming.
+
+## Future work (out of scope for v1)
+
+- HMAC or signature on the manifest (LAN-attacker mitigation).
+- Per-device staged rollouts (canary subset before full rollout).
+- Apply same OTA pattern to the original BLE-only `firmware/sensor-tag/`.
+- Server-side cleanup of old versioned dirs (currently manual).

--- a/docs/superpowers/specs/2026-04-25-sensor-tag-wifi-fleet-visibility-design.md
+++ b/docs/superpowers/specs/2026-04-25-sensor-tag-wifi-fleet-visibility-design.md
@@ -1,0 +1,140 @@
+# sensor-tag-wifi: fleet visibility & battery telemetry — Design
+
+**Date:** 2026-04-25
+**Branch:** `dev`
+**Scope:** Add per-reading firmware version, raw battery voltage, and WiFi RSSI to the MQTT payload. Defer heartbeat work to a tracked issue.
+
+## Goal
+
+Every reading published to `combsense/hive/<id>/reading` self-identifies which firmware build produced it, what the cell voltage was at sample time, and what the WiFi signal looked like at publish time. This makes the fleet diagnosable from Influx alone — no need to cross-reference deploy logs to know what version a tag is running, and no need to trust the SOC curve when raw mV is available.
+
+## Out of scope
+
+- **Heartbeat / read-failure publishing.** Decision: defer (option C from brainstorming). Tracked as a GitHub issue containing the A/B/C trade-off analysis. Revisit once fleet >3 tags.
+- iOS app changes. The Influx schema additions are non-breaking; existing fields are untouched.
+- Grafana panel updates. Additive only — operator can wire the new fields when wanted.
+
+## Payload shape
+
+```json
+{"id":"c5fffe12","v":"5423c04","t":1745520000,"t1":21.50,"t2":22.10,"vbat_mV":3987,"rssi":-58,"b":78}
+```
+
+**Field order:**
+- `id`, `v` — identity prefix (who said this, what build)
+- `t` — timestamp
+- `t1`, `t2`, optional `h1`, `h2` — sensor channels. Existing NaN/null and humidity-omit semantics preserved.
+- `vbat_mV`, `rssi`, `b` — diagnostics suffix
+
+**Always-emit semantics** (per option (a) from brainstorming):
+- `v` — always emitted. Falls back to literal `"unknown"` when `git describe` fails (existing [get_version.py](firmware/sensor-tag-wifi/get_version.py) behaviour).
+- `vbat_mV` — always emitted, even if 0. Mirrors the existing `b=0` USB-bench convention; downstream queries can filter `WHERE vbat_mV > 100`.
+- `rssi` — always emitted. Post-connect read is always valid since publish only happens after a successful WiFi connect.
+
+**Buffer headroom:** worst-case payload (`v0.1.2-12-g5423c04-dirty`, both humidities present, vbat_mV=4-digit, rssi=-3-digit) ≈ 135 bytes. `PAYLOAD_MAX_LEN = 160` ([include/config.h:84](firmware/sensor-tag-wifi/include/config.h#L84)) holds.
+
+## Field semantics: per-sample vs per-publish
+
+`vbat_mV` is a **per-sample** measurement — read at sample time alongside temperatures, persists in the RTC ring buffer across deep-sleep cycles. It belongs in `Reading`.
+
+`rssi` is a **per-publish** measurement — read once after WiFi connect, applies to all readings drained in that publish session. Storing it in `Reading` would be misleading (buffered readings get the current RSSI, not the RSSI at their sample time). It is passed as a parameter to `Payload::serialize`.
+
+`v` is a **compile-time constant** — same for every publish from a given build. Passed as a parameter (rather than referencing the macro inside `payload.cpp`) so unit tests can supply arbitrary version strings without rebuilding.
+
+## Code changes
+
+### [include/reading.h](firmware/sensor-tag-wifi/include/reading.h)
+Add one field. POD remains RTC-safe:
+```cpp
+struct Reading {
+    uint32_t timestamp;
+    float    temp1;
+    float    temp2;
+    float    humidity1;
+    float    humidity2;
+    uint16_t vbat_mV;     // NEW — raw battery voltage at sample time
+    uint8_t  battery_pct;
+};
+```
+
+### [src/battery.h](firmware/sensor-tag-wifi/src/battery.h) / [src/battery.cpp](firmware/sensor-tag-wifi/src/battery.cpp)
+Refactor to expose the underlying mV value, single ADC sweep:
+```cpp
+namespace Battery {
+    uint16_t readMillivolts();                       // ADC sweep + divider ratio
+    uint8_t  percentFromMillivolts(uint16_t mV);     // pure conversion
+    uint8_t  readPercent();                           // composition (kept as convenience)
+}
+```
+Caller in `sampleAndEnqueue()` does one sweep, derives both:
+```cpp
+r.vbat_mV     = Battery::readMillivolts();
+r.battery_pct = Battery::percentFromMillivolts(r.vbat_mV);
+```
+
+### [src/payload.h](firmware/sensor-tag-wifi/include/payload.h) / [src/payload.cpp](firmware/sensor-tag-wifi/src/payload.cpp)
+Extend `serialize()` signature with two trailing parameters:
+```cpp
+int serialize(const char* deviceId,
+              const char* fwVersion,
+              int8_t      rssi,
+              const Reading& r,
+              char* buf, size_t bufLen);
+```
+Emission order matches the documented payload shape above. `vbat_mV` and `rssi` use integer formats (`%u` and `%d`).
+
+### [src/mqtt_client.cpp](firmware/sensor-tag-wifi/src/mqtt_client.cpp)
+- Capture `int8_t rssi = static_cast<int8_t>(WiFi.RSSI())` once, after connect, before drain.
+- Pass `FIRMWARE_VERSION` and the captured rssi into `Payload::serialize()` for each buffered reading.
+
+### [deploy/tsdb/telegraf-combsense.conf](deploy/tsdb/telegraf-combsense.conf)
+Add three field blocks. All **fields** (not tags), all `optional = true` so older payloads from un-upgraded tags continue to parse:
+```toml
+[[inputs.mqtt_consumer.json_v2.field]]
+  path = "v"
+  rename = "fw_version"
+  type = "string"
+  optional = true
+[[inputs.mqtt_consumer.json_v2.field]]
+  path = "vbat_mV"
+  type = "int"
+  optional = true
+[[inputs.mqtt_consumer.json_v2.field]]
+  path = "rssi"
+  type = "int"
+  optional = true
+```
+String field for `fw_version` avoids Influx series-cardinality blow-up on every OTA (versus making it a tag).
+
+## Testing
+
+[firmware/sensor-tag-wifi/test/test_payload/test_payload.cpp](firmware/sensor-tag-wifi/test/test_payload/test_payload.cpp):
+
+- **Update all 6 existing tests** to pass `fwVersion="abc1234"` and `rssi=-58` (or similar fixtures), and update expected JSON strings to include `"v":"abc1234"` after `id`, and `"vbat_mV":<n>,"rssi":<n>` before `b`.
+- **Add 1 new test:** `test_serialize_with_unknown_version` — passes `fwVersion="unknown"`, asserts the literal appears in the payload.
+
+Result: 7 payload tests (was 6). Total native test count goes from 30 → 31.
+
+Verification command (per project instruction in user prompt):
+```
+pio test -e native -d firmware/sensor-tag-wifi
+```
+
+## Verification (pre-merge)
+
+1. `pio test -e native -d firmware/sensor-tag-wifi` — all native tests pass.
+2. `pio run -e xiao-c6-ds18b20` and `pio run -e xiao-c6-sht31` — both compile clean.
+3. Bench: flash one tag, serial-monitor, confirm a publish line shows the new payload shape.
+4. Telegraf: tail `/var/log/telegraf/telegraf.log` on combsense-tsdb after the bench tag publishes once — confirm no `json_v2` parse errors.
+5. Influx sanity: `from(bucket:"combsense") |> range(start:-5m) |> filter(fn:(r) => r._field == "fw_version")` returns the build sha.
+
+## Deferred follow-up
+
+Open a GitHub issue **on dev branch tasks** titled "sensor-tag-wifi heartbeat (read-failure visibility)" containing the A/B/C trade-off analysis from brainstorming, with recommendation to revisit when fleet exceeds 3 tags.
+
+## ROUTER update
+
+After merge, append to `.mex/ROUTER.md`:
+- Bullet under sensor-tag-wifi section: "Reading payload now self-identifies build (`v`) and includes raw battery mV + WiFi RSSI for diagnostics."
+- Telegraf line: "fw_version, vbat_mV, rssi captured as Influx fields."
+- Native test count: 30 → 31.

--- a/firmware/sensor-tag-wifi/get_version.py
+++ b/firmware/sensor-tag-wifi/get_version.py
@@ -1,0 +1,24 @@
+"""Inject FIRMWARE_VERSION as a build flag from `git describe`.
+
+Runs as a PlatformIO pre-script (extra_scripts = pre:get_version.py). Must
+be deterministic for cache hits — same git state must yield the same flag.
+"""
+import subprocess
+
+Import("env")  # noqa: F821 — provided by PlatformIO
+
+
+def _git_describe() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "describe", "--tags", "--always", "--dirty"],
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode("utf-8").strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+version = _git_describe()
+print(f"[get_version] FIRMWARE_VERSION={version}")
+env.Append(BUILD_FLAGS=[f'-DFIRMWARE_VERSION=\\"{version}\\"'])  # noqa: F821

--- a/firmware/sensor-tag-wifi/include/config.h
+++ b/firmware/sensor-tag-wifi/include/config.h
@@ -69,3 +69,12 @@ constexpr uint8_t  DS18B20_RESOLUTION_BITS      = 12;
 // =============================================================================
 
 constexpr size_t PAYLOAD_MAX_LEN = 160;
+
+// =============================================================================
+// OTA
+// =============================================================================
+
+constexpr const char* OTA_DEFAULT_HOST     = "192.168.1.61";
+constexpr uint8_t     OTA_BATTERY_FLOOR_PCT = 20;
+constexpr uint32_t    OTA_HTTP_TIMEOUT_MS  = 30000;
+constexpr const char* NVS_KEY_OTA_HOST     = "ota_host";

--- a/firmware/sensor-tag-wifi/include/config.h
+++ b/firmware/sensor-tag-wifi/include/config.h
@@ -4,18 +4,31 @@
 #include <cstdint>
 
 // =============================================================================
-// Pin Definitions — Seeed XIAO ESP32-C6
+// Pin Definitions
+//
+// Defaults target the Seeed XIAO ESP32-C6.
+//   PIN_ONE_WIRE_GPIO    — C6 default: GPIO2 (D2, 4.7 kΩ pullup to 3V3)
+//   PIN_BATTERY_ADC_GPIO — C6 default: GPIO0 (A0)
+//
+// Override at build time via -DPIN_ONE_WIRE_GPIO=N / -DPIN_BATTERY_ADC_GPIO=N
+// (e.g. Waveshare ESP32-S3-Zero uses GPIO4 / GPIO1).
 // =============================================================================
 
-// I2C (SHT31) — D4/D5
+// I2C (SHT31) — D4/D5 on XIAO C6; not overridable (SHT31 S3 variant not built)
 constexpr uint8_t PIN_I2C_SDA = 4;
 constexpr uint8_t PIN_I2C_SCL = 5;
 
-// 1-Wire (DS18B20) — D2 with 4.7kΩ pullup to 3V3
-constexpr uint8_t PIN_ONE_WIRE = 2;
+// 1-Wire (DS18B20)
+#ifndef PIN_ONE_WIRE_GPIO
+#define PIN_ONE_WIRE_GPIO 2
+#endif
+constexpr uint8_t PIN_ONE_WIRE = PIN_ONE_WIRE_GPIO;
 
-// Battery ADC — A0 (GPIO 0 on XIAO C6)
-constexpr uint8_t PIN_BATTERY_ADC = 0;
+// Battery ADC
+#ifndef PIN_BATTERY_ADC_GPIO
+#define PIN_BATTERY_ADC_GPIO 0
+#endif
+constexpr uint8_t PIN_BATTERY_ADC = PIN_BATTERY_ADC_GPIO;
 
 // =============================================================================
 // Power / Timing Defaults

--- a/firmware/sensor-tag-wifi/include/ota.h
+++ b/firmware/sensor-tag-wifi/include/ota.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Ota {
+    void validateOnBoot();
+    void onPublishSuccess();
+    void checkAndApply(uint8_t batteryPct);
+}

--- a/firmware/sensor-tag-wifi/include/ota_decision.h
+++ b/firmware/sensor-tag-wifi/include/ota_decision.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+
+bool shouldApply(const char* current,
+                 const char* manifest,
+                 const char* failed,
+                 uint8_t batteryPct);
+
+enum class ValidateAction {
+    NoOp,
+    ClearAttempted,
+    RecordFailed,
+};
+
+ValidateAction validateOnBootAction(const char* firmwareVersion,
+                                    const char* attempted,
+                                    bool isPendingVerify);

--- a/firmware/sensor-tag-wifi/include/ota_manifest.h
+++ b/firmware/sensor-tag-wifi/include/ota_manifest.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstddef>
+
+struct Manifest {
+    char version[32];
+    char url[256];
+    char sha256[65];   // 64 hex chars + null
+    size_t size;
+};
+
+bool parseManifest(const char* json, size_t len, Manifest& out);

--- a/firmware/sensor-tag-wifi/include/ota_sha256.h
+++ b/firmware/sensor-tag-wifi/include/ota_sha256.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+class Sha256Streamer {
+public:
+    Sha256Streamer();
+    ~Sha256Streamer();
+
+    void reset();
+    void update(const uint8_t* data, size_t len);
+    void finalizeToHex(char outHex[65]);   // writes 64 lowercase hex + null
+
+    bool matches(const char* expectedHex);  // call after finalizeToHex
+
+private:
+    void* impl_;
+    char lastHex_[65];
+};

--- a/firmware/sensor-tag-wifi/include/ota_sha256.h
+++ b/firmware/sensor-tag-wifi/include/ota_sha256.h
@@ -8,6 +8,9 @@ public:
     Sha256Streamer();
     ~Sha256Streamer();
 
+    Sha256Streamer(const Sha256Streamer&) = delete;
+    Sha256Streamer& operator=(const Sha256Streamer&) = delete;
+
     void reset();
     void update(const uint8_t* data, size_t len);
     void finalizeToHex(char outHex[65]);   // writes 64 lowercase hex + null

--- a/firmware/sensor-tag-wifi/include/ota_state.h
+++ b/firmware/sensor-tag-wifi/include/ota_state.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstddef>
+
+namespace OtaState {
+    void getAttempted(char* out, size_t outCap);
+    void setAttempted(const char* version);
+    void clearAttempted();
+
+    void getFailed(char* out, size_t outCap);
+    void setFailed(const char* version);
+    void clearFailed();
+}

--- a/firmware/sensor-tag-wifi/include/payload.h
+++ b/firmware/sensor-tag-wifi/include/payload.h
@@ -1,16 +1,24 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include "reading.h"
 
 namespace Payload {
 
 /// Serialize a reading into a JSON string.
-/// @param deviceId  8-char hex device ID (null-terminated)
-/// @param r         reading to serialize
-/// @param buf       output buffer
-/// @param bufLen    size of output buffer
-/// @return          number of bytes written (excluding null), or -1 on overflow
-int serialize(const char* deviceId, const Reading& r, char* buf, size_t bufLen);
+/// @param deviceId   8-char hex device ID (null-terminated)
+/// @param fwVersion  null-terminated firmware version string (from FIRMWARE_VERSION
+///                   build flag; `"unknown"` when git describe failed)
+/// @param rssi       WiFi RSSI captured post-connect at publish time, in dBm
+/// @param r          reading to serialize
+/// @param buf        output buffer
+/// @param bufLen     size of output buffer
+/// @return           number of bytes written (excluding null), or -1 on overflow
+int serialize(const char* deviceId,
+              const char* fwVersion,
+              int8_t      rssi,
+              const Reading& r,
+              char* buf, size_t bufLen);
 
 }  // namespace Payload

--- a/firmware/sensor-tag-wifi/include/picosha2.h
+++ b/firmware/sensor-tag-wifi/include/picosha2.h
@@ -1,0 +1,377 @@
+/*
+The MIT License (MIT)
+
+Copyright (C) 2017 okdshin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#ifndef PICOSHA2_H
+#define PICOSHA2_H
+// picosha2:20140213
+
+#ifndef PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR
+#define PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR \
+    1048576  //=1024*1024: default is 1MB memory
+#endif
+
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <sstream>
+#include <vector>
+#include <fstream>
+namespace picosha2 {
+typedef unsigned long word_t;
+typedef unsigned char byte_t;
+
+static const size_t k_digest_size = 32;
+
+namespace detail {
+inline byte_t mask_8bit(byte_t x) { return x & 0xff; }
+
+inline word_t mask_32bit(word_t x) { return x & 0xffffffff; }
+
+const word_t add_constant[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+const word_t initial_message_digest[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372,
+                                          0xa54ff53a, 0x510e527f, 0x9b05688c,
+                                          0x1f83d9ab, 0x5be0cd19};
+
+inline word_t ch(word_t x, word_t y, word_t z) { return (x & y) ^ ((~x) & z); }
+
+inline word_t maj(word_t x, word_t y, word_t z) {
+    return (x & y) ^ (x & z) ^ (y & z);
+}
+
+inline word_t rotr(word_t x, std::size_t n) {
+    assert(n < 32);
+    return mask_32bit((x >> n) | (x << (32 - n)));
+}
+
+inline word_t bsig0(word_t x) { return rotr(x, 2) ^ rotr(x, 13) ^ rotr(x, 22); }
+
+inline word_t bsig1(word_t x) { return rotr(x, 6) ^ rotr(x, 11) ^ rotr(x, 25); }
+
+inline word_t shr(word_t x, std::size_t n) {
+    assert(n < 32);
+    return x >> n;
+}
+
+inline word_t ssig0(word_t x) { return rotr(x, 7) ^ rotr(x, 18) ^ shr(x, 3); }
+
+inline word_t ssig1(word_t x) { return rotr(x, 17) ^ rotr(x, 19) ^ shr(x, 10); }
+
+template <typename RaIter1, typename RaIter2>
+void hash256_block(RaIter1 message_digest, RaIter2 first, RaIter2 last) {
+    assert(first + 64 == last);
+    static_cast<void>(last);  // for avoiding unused-variable warning
+    word_t w[64];
+    std::fill(w, w + 64, word_t(0));
+    for (std::size_t i = 0; i < 16; ++i) {
+        w[i] = (static_cast<word_t>(mask_8bit(*(first + i * 4))) << 24) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 1))) << 16) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 2))) << 8) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 3))));
+    }
+    for (std::size_t i = 16; i < 64; ++i) {
+        w[i] = mask_32bit(ssig1(w[i - 2]) + w[i - 7] + ssig0(w[i - 15]) +
+                          w[i - 16]);
+    }
+
+    word_t a = *message_digest;
+    word_t b = *(message_digest + 1);
+    word_t c = *(message_digest + 2);
+    word_t d = *(message_digest + 3);
+    word_t e = *(message_digest + 4);
+    word_t f = *(message_digest + 5);
+    word_t g = *(message_digest + 6);
+    word_t h = *(message_digest + 7);
+
+    for (std::size_t i = 0; i < 64; ++i) {
+        word_t temp1 = h + bsig1(e) + ch(e, f, g) + add_constant[i] + w[i];
+        word_t temp2 = bsig0(a) + maj(a, b, c);
+        h = g;
+        g = f;
+        f = e;
+        e = mask_32bit(d + temp1);
+        d = c;
+        c = b;
+        b = a;
+        a = mask_32bit(temp1 + temp2);
+    }
+    *message_digest += a;
+    *(message_digest + 1) += b;
+    *(message_digest + 2) += c;
+    *(message_digest + 3) += d;
+    *(message_digest + 4) += e;
+    *(message_digest + 5) += f;
+    *(message_digest + 6) += g;
+    *(message_digest + 7) += h;
+    for (std::size_t i = 0; i < 8; ++i) {
+        *(message_digest + i) = mask_32bit(*(message_digest + i));
+    }
+}
+
+}  // namespace detail
+
+template <typename InIter>
+void output_hex(InIter first, InIter last, std::ostream& os) {
+    os.setf(std::ios::hex, std::ios::basefield);
+    while (first != last) {
+        os.width(2);
+        os.fill('0');
+        os << static_cast<unsigned int>(*first);
+        ++first;
+    }
+    os.setf(std::ios::dec, std::ios::basefield);
+}
+
+template <typename InIter>
+void bytes_to_hex_string(InIter first, InIter last, std::string& hex_str) {
+    std::ostringstream oss;
+    output_hex(first, last, oss);
+    hex_str.assign(oss.str());
+}
+
+template <typename InContainer>
+void bytes_to_hex_string(const InContainer& bytes, std::string& hex_str) {
+    bytes_to_hex_string(bytes.begin(), bytes.end(), hex_str);
+}
+
+template <typename InIter>
+std::string bytes_to_hex_string(InIter first, InIter last) {
+    std::string hex_str;
+    bytes_to_hex_string(first, last, hex_str);
+    return hex_str;
+}
+
+template <typename InContainer>
+std::string bytes_to_hex_string(const InContainer& bytes) {
+    std::string hex_str;
+    bytes_to_hex_string(bytes, hex_str);
+    return hex_str;
+}
+
+class hash256_one_by_one {
+   public:
+    hash256_one_by_one() { init(); }
+
+    void init() {
+        buffer_.clear();
+        std::fill(data_length_digits_, data_length_digits_ + 4, word_t(0));
+        std::copy(detail::initial_message_digest,
+                  detail::initial_message_digest + 8, h_);
+    }
+
+    template <typename RaIter>
+    void process(RaIter first, RaIter last) {
+        add_to_data_length(static_cast<word_t>(std::distance(first, last)));
+        std::copy(first, last, std::back_inserter(buffer_));
+        std::size_t i = 0;
+        for (; i + 64 <= buffer_.size(); i += 64) {
+            detail::hash256_block(h_, buffer_.begin() + i,
+                                  buffer_.begin() + i + 64);
+        }
+        buffer_.erase(buffer_.begin(), buffer_.begin() + i);
+    }
+
+    void finish() {
+        byte_t temp[64];
+        std::fill(temp, temp + 64, byte_t(0));
+        std::size_t remains = buffer_.size();
+        std::copy(buffer_.begin(), buffer_.end(), temp);
+        temp[remains] = 0x80;
+
+        if (remains > 55) {
+            std::fill(temp + remains + 1, temp + 64, byte_t(0));
+            detail::hash256_block(h_, temp, temp + 64);
+            std::fill(temp, temp + 64 - 4, byte_t(0));
+        } else {
+            std::fill(temp + remains + 1, temp + 64 - 4, byte_t(0));
+        }
+
+        write_data_bit_length(&(temp[56]));
+        detail::hash256_block(h_, temp, temp + 64);
+    }
+
+    template <typename OutIter>
+    void get_hash_bytes(OutIter first, OutIter last) const {
+        for (const word_t* iter = h_; iter != h_ + 8; ++iter) {
+            for (std::size_t i = 0; i < 4 && first != last; ++i) {
+                *(first++) = detail::mask_8bit(
+                    static_cast<byte_t>((*iter >> (24 - 8 * i))));
+            }
+        }
+    }
+
+   private:
+    void add_to_data_length(word_t n) {
+        word_t carry = 0;
+        data_length_digits_[0] += n;
+        for (std::size_t i = 0; i < 4; ++i) {
+            data_length_digits_[i] += carry;
+            if (data_length_digits_[i] >= 65536u) {
+                carry = data_length_digits_[i] >> 16;
+                data_length_digits_[i] &= 65535u;
+            } else {
+                break;
+            }
+        }
+    }
+    void write_data_bit_length(byte_t* begin) {
+        word_t data_bit_length_digits[4];
+        std::copy(data_length_digits_, data_length_digits_ + 4,
+                  data_bit_length_digits);
+
+        // convert byte length to bit length (multiply 8 or shift 3 times left)
+        word_t carry = 0;
+        for (std::size_t i = 0; i < 4; ++i) {
+            word_t before_val = data_bit_length_digits[i];
+            data_bit_length_digits[i] <<= 3;
+            data_bit_length_digits[i] |= carry;
+            data_bit_length_digits[i] &= 65535u;
+            carry = (before_val >> (16 - 3)) & 65535u;
+        }
+
+        // write data_bit_length
+        for (int i = 3; i >= 0; --i) {
+            (*begin++) = static_cast<byte_t>(data_bit_length_digits[i] >> 8);
+            (*begin++) = static_cast<byte_t>(data_bit_length_digits[i]);
+        }
+    }
+    std::vector<byte_t> buffer_;
+    word_t data_length_digits_[4];  // as 64bit integer (16bit x 4 integer)
+    word_t h_[8];
+};
+
+inline void get_hash_hex_string(const hash256_one_by_one& hasher,
+                                std::string& hex_str) {
+    byte_t hash[k_digest_size];
+    hasher.get_hash_bytes(hash, hash + k_digest_size);
+    return bytes_to_hex_string(hash, hash + k_digest_size, hex_str);
+}
+
+inline std::string get_hash_hex_string(const hash256_one_by_one& hasher) {
+    std::string hex_str;
+    get_hash_hex_string(hasher, hex_str);
+    return hex_str;
+}
+
+namespace impl {
+template <typename RaIter, typename OutIter>
+void hash256_impl(RaIter first, RaIter last, OutIter first2, OutIter last2, int,
+                  std::random_access_iterator_tag) {
+    hash256_one_by_one hasher;
+    // hasher.init();
+    hasher.process(first, last);
+    hasher.finish();
+    hasher.get_hash_bytes(first2, last2);
+}
+
+template <typename InputIter, typename OutIter>
+void hash256_impl(InputIter first, InputIter last, OutIter first2,
+                  OutIter last2, int buffer_size, std::input_iterator_tag) {
+    std::vector<byte_t> buffer(buffer_size);
+    hash256_one_by_one hasher;
+    // hasher.init();
+    while (first != last) {
+        int size = buffer_size;
+        for (int i = 0; i != buffer_size; ++i, ++first) {
+            if (first == last) {
+                size = i;
+                break;
+            }
+            buffer[i] = *first;
+        }
+        hasher.process(buffer.begin(), buffer.begin() + size);
+    }
+    hasher.finish();
+    hasher.get_hash_bytes(first2, last2);
+}
+}
+
+template <typename InIter, typename OutIter>
+void hash256(InIter first, InIter last, OutIter first2, OutIter last2,
+             int buffer_size = PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR) {
+    picosha2::impl::hash256_impl(
+        first, last, first2, last2, buffer_size,
+        typename std::iterator_traits<InIter>::iterator_category());
+}
+
+template <typename InIter, typename OutContainer>
+void hash256(InIter first, InIter last, OutContainer& dst) {
+    hash256(first, last, dst.begin(), dst.end());
+}
+
+template <typename InContainer, typename OutIter>
+void hash256(const InContainer& src, OutIter first, OutIter last) {
+    hash256(src.begin(), src.end(), first, last);
+}
+
+template <typename InContainer, typename OutContainer>
+void hash256(const InContainer& src, OutContainer& dst) {
+    hash256(src.begin(), src.end(), dst.begin(), dst.end());
+}
+
+template <typename InIter>
+void hash256_hex_string(InIter first, InIter last, std::string& hex_str) {
+    byte_t hashed[k_digest_size];
+    hash256(first, last, hashed, hashed + k_digest_size);
+    std::ostringstream oss;
+    output_hex(hashed, hashed + k_digest_size, oss);
+    hex_str.assign(oss.str());
+}
+
+template <typename InIter>
+std::string hash256_hex_string(InIter first, InIter last) {
+    std::string hex_str;
+    hash256_hex_string(first, last, hex_str);
+    return hex_str;
+}
+
+inline void hash256_hex_string(const std::string& src, std::string& hex_str) {
+    hash256_hex_string(src.begin(), src.end(), hex_str);
+}
+
+template <typename InContainer>
+void hash256_hex_string(const InContainer& src, std::string& hex_str) {
+    hash256_hex_string(src.begin(), src.end(), hex_str);
+}
+
+template <typename InContainer>
+std::string hash256_hex_string(const InContainer& src) {
+    return hash256_hex_string(src.begin(), src.end());
+}
+template<typename OutIter>void hash256(std::ifstream& f, OutIter first, OutIter last){
+    hash256(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>(), first,last);
+
+}
+}// namespace picosha2
+#endif  // PICOSHA2_H

--- a/firmware/sensor-tag-wifi/include/reading.h
+++ b/firmware/sensor-tag-wifi/include/reading.h
@@ -21,3 +21,7 @@ struct Reading {
     uint16_t vbat_mV;      // raw battery voltage at sample time
     uint8_t  battery_pct;  // 0..100
 };
+
+static_assert(sizeof(Reading) == 24,
+              "Reading layout changed — bump RingBuffer MAGIC to invalidate "
+              "stale RTC slots after OTA. See ring_buffer.cpp.");

--- a/firmware/sensor-tag-wifi/include/reading.h
+++ b/firmware/sensor-tag-wifi/include/reading.h
@@ -8,11 +8,16 @@
 /// two humidity channels. NAN means the channel is unavailable (DS18B20 build,
 /// or a single SHT31 failing on a dual-sensor board) and is omitted from the
 /// serialized payload.
+///
+/// `vbat_mV` is the raw ADC reading (divider-corrected) at sample time, kept
+/// alongside `battery_pct` so downstream consumers can apply a better SOC
+/// curve later without a firmware change. See issue #10.
 struct Reading {
     uint32_t timestamp;    // unix seconds
     float    temp1;        // brood (°C)
     float    temp2;        // top   (°C)
     float    humidity1;    // brood (%RH) — NAN if unavailable
     float    humidity2;    // top   (%RH) — NAN if unavailable
+    uint16_t vbat_mV;      // raw battery voltage at sample time
     uint8_t  battery_pct;  // 0..100
 };

--- a/firmware/sensor-tag-wifi/partitions_tag.csv
+++ b/firmware/sensor-tag-wifi/partitions_tag.csv
@@ -1,5 +1,6 @@
 # Name,     Type, SubType, Offset,   Size,     Flags
 nvs,        data, nvs,     0x9000,   0x5000,
 otadata,    data, ota,     0xE000,   0x2000,
-app0,       app,  ota_0,   0x10000,  0x300000,
+app0,       app,  ota_0,   0x10000,  0x180000,
+app1,       app,  ota_1,   0x190000, 0x180000,
 spiffs,     data, spiffs,  0x310000, 0xF0000,

--- a/firmware/sensor-tag-wifi/platformio.ini
+++ b/firmware/sensor-tag-wifi/platformio.ini
@@ -14,6 +14,7 @@ build_flags =
 [env:xiao-c6-sht31]
 extends = env:esp32-base
 board = esp32-c6-devkitm-1
+extra_scripts = pre:get_version.py
 lib_deps =
     adafruit/Adafruit SHT31 Library@^2.2.2
     knolleary/PubSubClient@^2.8
@@ -23,6 +24,7 @@ build_flags =
     -I../shared
     -DCORE_DEBUG_LEVEL=3
     -DSENSOR_SHT31
+    -DOTA_VARIANT=\"sht31\"
 build_src_filter =
     +<*>
     -<sensor_ds18b20.cpp>
@@ -30,6 +32,7 @@ build_src_filter =
 [env:xiao-c6-ds18b20]
 extends = env:esp32-base
 board = esp32-c6-devkitm-1
+extra_scripts = pre:get_version.py
 lib_deps =
     pstolarz/OneWireNg@^0.14.1
     milesburton/DallasTemperature@^3.11.0
@@ -41,6 +44,7 @@ build_flags =
     -I../shared
     -DCORE_DEBUG_LEVEL=3
     -DSENSOR_DS18B20
+    -DOTA_VARIANT=\"ds18b20\"
 build_src_filter =
     +<*>
     -<sensor_sht31.cpp>

--- a/firmware/sensor-tag-wifi/platformio.ini
+++ b/firmware/sensor-tag-wifi/platformio.ini
@@ -55,3 +55,4 @@ build_flags =
     -Isrc
 build_src_filter =
     +<payload.cpp>
+    +<ota_manifest.cpp>

--- a/firmware/sensor-tag-wifi/platformio.ini
+++ b/firmware/sensor-tag-wifi/platformio.ini
@@ -49,6 +49,34 @@ build_src_filter =
     +<*>
     -<sensor_sht31.cpp>
 
+[env:waveshare-s3zero-ds18b20]
+extends = env:esp32-base
+# waveshare_esp32_s3_zero is not in the pioarduino board index; use the generic
+# S3 devkit and constrain flash to 4 MB to match the S3-MINI-1 module.
+board = esp32-s3-devkitc-1
+board_build.flash_size = 4MB
+board_upload.flash_size = 4MB
+board_build.flash_mode = qio
+board_build.f_flash = 80000000L
+extra_scripts = pre:get_version.py
+lib_deps =
+    pstolarz/OneWireNg@^0.14.1
+    milesburton/DallasTemperature@^3.11.0
+    knolleary/PubSubClient@^2.8
+    Networking
+lib_ignore = OneWire
+build_flags =
+    ${env:esp32-base.build_flags}
+    -I../shared
+    -DCORE_DEBUG_LEVEL=3
+    -DSENSOR_DS18B20
+    -DOTA_VARIANT=\"s3-ds18b20\"
+    -DPIN_ONE_WIRE_GPIO=4
+    -DPIN_BATTERY_ADC_GPIO=1
+build_src_filter =
+    +<*>
+    -<sensor_sht31.cpp>
+
 [env:native]
 platform = native
 test_framework = unity

--- a/firmware/sensor-tag-wifi/platformio.ini
+++ b/firmware/sensor-tag-wifi/platformio.ini
@@ -57,3 +57,4 @@ build_src_filter =
     +<payload.cpp>
     +<ota_manifest.cpp>
     +<ota_decision.cpp>
+    +<ota_sha256.cpp>

--- a/firmware/sensor-tag-wifi/platformio.ini
+++ b/firmware/sensor-tag-wifi/platformio.ini
@@ -56,3 +56,4 @@ build_flags =
 build_src_filter =
     +<payload.cpp>
     +<ota_manifest.cpp>
+    +<ota_decision.cpp>

--- a/firmware/sensor-tag-wifi/src/battery.cpp
+++ b/firmware/sensor-tag-wifi/src/battery.cpp
@@ -5,8 +5,6 @@
 
 namespace {
 
-constexpr float VBAT_FULL_MV  = 4200.0f;
-constexpr float VBAT_EMPTY_MV = 3300.0f;
 constexpr float DIVIDER_RATIO = 2.0f;   // 100k / 100k → 2:1
 constexpr uint8_t ADC_SAMPLES = 8;
 
@@ -14,17 +12,19 @@ constexpr uint8_t ADC_SAMPLES = 8;
 
 namespace Battery {
 
-uint8_t readPercent() {
+uint16_t readMillivolts() {
     uint32_t acc = 0;
     for (uint8_t i = 0; i < ADC_SAMPLES; ++i) {
         acc += analogReadMilliVolts(PIN_BATTERY_ADC);
     }
     float vbat = (acc / static_cast<float>(ADC_SAMPLES)) * DIVIDER_RATIO;
+    if (vbat < 0.0f) return 0;
+    if (vbat > UINT16_MAX) return UINT16_MAX;
+    return static_cast<uint16_t>(vbat);
+}
 
-    if (vbat >= VBAT_FULL_MV)  return 100;
-    if (vbat <= VBAT_EMPTY_MV) return 0;
-    return static_cast<uint8_t>(
-        (vbat - VBAT_EMPTY_MV) * 100.0f / (VBAT_FULL_MV - VBAT_EMPTY_MV));
+uint8_t readPercent() {
+    return percentFromMillivolts(readMillivolts());
 }
 
 }  // namespace Battery

--- a/firmware/sensor-tag-wifi/src/battery.cpp
+++ b/firmware/sensor-tag-wifi/src/battery.cpp
@@ -23,8 +23,5 @@ uint16_t readMillivolts() {
     return static_cast<uint16_t>(vbat);
 }
 
-uint8_t readPercent() {
-    return percentFromMillivolts(readMillivolts());
-}
 
 }  // namespace Battery

--- a/firmware/sensor-tag-wifi/src/battery.h
+++ b/firmware/sensor-tag-wifi/src/battery.h
@@ -4,9 +4,26 @@
 
 namespace Battery {
 
-/// Read battery voltage via ADC and return percent (0..100).
-/// Assumes 18650 Li-ion: 4.20V full, 3.30V empty, with a 2:1 divider
-/// (100 kΩ / 100 kΩ) into the ADC pin.
+constexpr uint16_t VBAT_FULL_MV  = 4200;
+constexpr uint16_t VBAT_EMPTY_MV = 3300;
+
+/// Read raw battery voltage via ADC, divider-corrected. Returns mV.
+/// Implemented in battery.cpp; requires Arduino runtime.
+uint16_t readMillivolts();
+
+/// Pure conversion: clamp + linear-interpolate mV to 0..100% Li-ion SOC.
+/// Inline so native unit tests can link without Arduino. The 4200/3300 mV
+/// endpoints assume 18650 Li-ion; see issue #10 for replacing the linear
+/// formula with a real discharge curve once vbat_mV telemetry is collected.
+inline uint8_t percentFromMillivolts(uint16_t mV) {
+    if (mV >= VBAT_FULL_MV)  return 100;
+    if (mV <= VBAT_EMPTY_MV) return 0;
+    return static_cast<uint8_t>(
+        (static_cast<float>(mV) - VBAT_EMPTY_MV) * 100.0f /
+        (VBAT_FULL_MV - VBAT_EMPTY_MV));
+}
+
+/// Convenience: composes readMillivolts() + percentFromMillivolts().
 uint8_t readPercent();
 
 }  // namespace Battery

--- a/firmware/sensor-tag-wifi/src/battery.h
+++ b/firmware/sensor-tag-wifi/src/battery.h
@@ -23,7 +23,5 @@ inline uint8_t percentFromMillivolts(uint16_t mV) {
         (VBAT_FULL_MV - VBAT_EMPTY_MV));
 }
 
-/// Convenience: composes readMillivolts() + percentFromMillivolts().
-uint8_t readPercent();
 
 }  // namespace Battery

--- a/firmware/sensor-tag-wifi/src/main.cpp
+++ b/firmware/sensor-tag-wifi/src/main.cpp
@@ -122,7 +122,8 @@ void setup() {
     delay(2000);
 
     initDeviceId();
-    Serial.printf("[MAIN] combsense sensor-tag-wifi id=%s\n", deviceId);
+    Serial.printf("[MAIN] combsense sensor-tag-wifi id=%s version=%s\n",
+                  deviceId, FIRMWARE_VERSION);
 
     Ota::validateOnBoot();
 

--- a/firmware/sensor-tag-wifi/src/main.cpp
+++ b/firmware/sensor-tag-wifi/src/main.cpp
@@ -12,10 +12,13 @@
 #include "wifi_manager.h"
 #include "mqtt_client.h"
 #include "serial_console.h"
+#include "ota.h"
 
 namespace {
 
 RTC_DATA_ATTR uint16_t rtcSampleCounter = 0;
+
+uint8_t lastBatteryPct = 0;
 
 char deviceId[9] = {0};
 
@@ -69,6 +72,7 @@ void drainBuffer() {
         if (!MqttClient::publish(deviceId, r)) break;
         RingBuffer::popOldest();
         sent++;
+        Ota::onPublishSuccess();
     }
     Serial.printf("[MAIN] sent %u / remaining %u\n", sent, RingBuffer::size());
 
@@ -92,6 +96,7 @@ void sampleAndEnqueue() {
     }
 
     r.battery_pct = Battery::readPercent();
+    lastBatteryPct = r.battery_pct;
 
     // System clock is set by drainBuffer()'s NTP sync and persists across deep
     // sleep. Samples taken before the first successful upload are tagged 0 and
@@ -118,6 +123,8 @@ void setup() {
 
     initDeviceId();
     Serial.printf("[MAIN] combsense sensor-tag-wifi id=%s\n", deviceId);
+
+    Ota::validateOnBoot();
 
     RingBuffer::initIfColdBoot();
 
@@ -149,6 +156,10 @@ void setup() {
     } else {
         Serial.printf("[MAIN] not uploading this cycle (%u/%u)\n",
                       rtcSampleCounter, cfg.uploadEveryN);
+    }
+
+    if (rtcSampleCounter == 0 && lastBatteryPct > 0) {
+        Ota::checkAndApply(lastBatteryPct);
     }
 
     Serial.printf("[MAIN] sleeping %lus\n", (unsigned long)cfg.sampleIntervalSec);

--- a/firmware/sensor-tag-wifi/src/main.cpp
+++ b/firmware/sensor-tag-wifi/src/main.cpp
@@ -62,6 +62,8 @@ void uploadAndCheckOta(uint8_t batteryPct) {
 
     if (RingBuffer::size() > 0) {
         if (MqttClient::connect(deviceId)) {
+            // WiFi.RSSI() is int32_t; real-world range -100..-30 dBm fits int8_t.
+            // Captured post-connect so association is confirmed.
             int8_t sessionRssi = static_cast<int8_t>(WiFi.RSSI());
             Serial.printf("[MAIN] mqtt connected rssi=%d dBm\n", sessionRssi);
             uint8_t sent = 0;

--- a/firmware/sensor-tag-wifi/src/main.cpp
+++ b/firmware/sensor-tag-wifi/src/main.cpp
@@ -46,12 +46,12 @@ Config loadConfig() {
     return c;
 }
 
-/// Drain the RTC ring buffer over MQTT. Leaves unsent readings in place.
-void drainBuffer() {
-    if (RingBuffer::size() == 0) return;
-
+/// Drain readings over MQTT and run the OTA check inside a single WiFi window.
+/// OTA must share the radio session with MQTT — a separate connect after
+/// disconnect leaves a window where WiFi.mode(OFF) makes esp_http_client fail.
+void uploadAndCheckOta(uint8_t batteryPct) {
     if (!WifiManager::connect()) {
-        Serial.println("[MAIN] no wifi — keeping buffer");
+        Serial.println("[MAIN] no wifi — keeping buffer, skipping OTA");
         return;
     }
 
@@ -59,24 +59,28 @@ void drainBuffer() {
     // deep sleep once set, so subsequent samples get real timestamps.
     WifiManager::getUnixTime();
 
-    if (!MqttClient::connect(deviceId)) {
-        Serial.println("[MAIN] no mqtt — keeping buffer");
-        WifiManager::disconnect();
-        return;
+    if (RingBuffer::size() > 0) {
+        if (MqttClient::connect(deviceId)) {
+            uint8_t sent = 0;
+            while (RingBuffer::size() > 0) {
+                Reading r;
+                if (!RingBuffer::peekOldest(r)) break;
+                if (!MqttClient::publish(deviceId, r)) break;
+                RingBuffer::popOldest();
+                sent++;
+                Ota::onPublishSuccess();
+            }
+            Serial.printf("[MAIN] sent %u / remaining %u\n", sent, RingBuffer::size());
+            MqttClient::disconnect();
+        } else {
+            Serial.println("[MAIN] no mqtt — keeping buffer");
+        }
     }
 
-    uint8_t sent = 0;
-    while (RingBuffer::size() > 0) {
-        Reading r;
-        if (!RingBuffer::peekOldest(r)) break;
-        if (!MqttClient::publish(deviceId, r)) break;
-        RingBuffer::popOldest();
-        sent++;
-        Ota::onPublishSuccess();
+    if (batteryPct > 0) {
+        Ota::checkAndApply(batteryPct);
     }
-    Serial.printf("[MAIN] sent %u / remaining %u\n", sent, RingBuffer::size());
 
-    MqttClient::disconnect();
     WifiManager::disconnect();
 }
 
@@ -152,15 +156,11 @@ void setup() {
     rtcSampleCounter++;
 
     if (rtcSampleCounter >= cfg.uploadEveryN) {
-        drainBuffer();
+        uploadAndCheckOta(lastBatteryPct);
         rtcSampleCounter = 0;
     } else {
         Serial.printf("[MAIN] not uploading this cycle (%u/%u)\n",
                       rtcSampleCounter, cfg.uploadEveryN);
-    }
-
-    if (rtcSampleCounter == 0 && lastBatteryPct > 0) {
-        Ota::checkAndApply(lastBatteryPct);
     }
 
     Serial.printf("[MAIN] sleeping %lus\n", (unsigned long)cfg.sampleIntervalSec);

--- a/firmware/sensor-tag-wifi/src/main.cpp
+++ b/firmware/sensor-tag-wifi/src/main.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <Preferences.h>
+#include <WiFi.h>
 #include <esp_mac.h>
 #include <esp_sleep.h>
 
@@ -61,11 +62,13 @@ void uploadAndCheckOta(uint8_t batteryPct) {
 
     if (RingBuffer::size() > 0) {
         if (MqttClient::connect(deviceId)) {
+            int8_t sessionRssi = static_cast<int8_t>(WiFi.RSSI());
+            Serial.printf("[MAIN] mqtt connected rssi=%d dBm\n", sessionRssi);
             uint8_t sent = 0;
             while (RingBuffer::size() > 0) {
                 Reading r;
                 if (!RingBuffer::peekOldest(r)) break;
-                if (!MqttClient::publish(deviceId, r)) break;
+                if (!MqttClient::publish(deviceId, r, sessionRssi)) break;
                 RingBuffer::popOldest();
                 sent++;
                 Ota::onPublishSuccess();
@@ -99,7 +102,8 @@ void sampleAndEnqueue() {
         return;
     }
 
-    r.battery_pct = Battery::readPercent();
+    r.vbat_mV     = Battery::readMillivolts();
+    r.battery_pct = Battery::percentFromMillivolts(r.vbat_mV);
     lastBatteryPct = r.battery_pct;
 
     // System clock is set by drainBuffer()'s NTP sync and persists across deep
@@ -110,9 +114,9 @@ void sampleAndEnqueue() {
     r.timestamp = (now > 1700000000) ? static_cast<uint32_t>(now) : 0;
 
     RingBuffer::push(r);
-    Serial.printf("[MAIN] sample t1=%.2f t2=%.2f h1=%.2f h2=%.2f b=%u buffered=%u\n",
-                  r.temp1, r.temp2, r.humidity1, r.humidity2, r.battery_pct,
-                  RingBuffer::size());
+    Serial.printf("[MAIN] sample t1=%.2f t2=%.2f h1=%.2f h2=%.2f vbat=%umV b=%u buffered=%u\n",
+                  r.temp1, r.temp2, r.humidity1, r.humidity2,
+                  r.vbat_mV, r.battery_pct, RingBuffer::size());
 }
 
 }  // anonymous namespace

--- a/firmware/sensor-tag-wifi/src/mqtt_client.cpp
+++ b/firmware/sensor-tag-wifi/src/mqtt_client.cpp
@@ -59,14 +59,12 @@ bool connect(const char* deviceId) {
     return ok;
 }
 
-bool publish(const char* deviceId, const Reading& r) {
+bool publish(const char* deviceId, const Reading& r, int8_t rssi) {
     char topic[96];
     snprintf(topic, sizeof(topic), "%s%s/reading", MQTT_TOPIC_PREFIX, deviceId);
 
     char payload[PAYLOAD_MAX_LEN];
-    // RSSI captured post-connect — wired in next task; placeholder 0 here
-    // makes the call site type-check during the payload-shape rollout.
-    int n = Payload::serialize(deviceId, FIRMWARE_VERSION, 0, r, payload, sizeof(payload));
+    int n = Payload::serialize(deviceId, FIRMWARE_VERSION, rssi, r, payload, sizeof(payload));
     if (n < 0) {
         Serial.println("[MQTT] payload too large");
         return false;

--- a/firmware/sensor-tag-wifi/src/mqtt_client.cpp
+++ b/firmware/sensor-tag-wifi/src/mqtt_client.cpp
@@ -2,6 +2,10 @@
 #include "config.h"
 #include "payload.h"
 
+#ifndef FIRMWARE_VERSION
+#define FIRMWARE_VERSION "unknown"
+#endif
+
 #include <Arduino.h>
 #include <WiFi.h>
 #include <WiFiClient.h>
@@ -60,7 +64,9 @@ bool publish(const char* deviceId, const Reading& r) {
     snprintf(topic, sizeof(topic), "%s%s/reading", MQTT_TOPIC_PREFIX, deviceId);
 
     char payload[PAYLOAD_MAX_LEN];
-    int n = Payload::serialize(deviceId, r, payload, sizeof(payload));
+    // RSSI captured post-connect — wired in next task; placeholder 0 here
+    // makes the call site type-check during the payload-shape rollout.
+    int n = Payload::serialize(deviceId, FIRMWARE_VERSION, 0, r, payload, sizeof(payload));
     if (n < 0) {
         Serial.println("[MQTT] payload too large");
         return false;

--- a/firmware/sensor-tag-wifi/src/mqtt_client.h
+++ b/firmware/sensor-tag-wifi/src/mqtt_client.h
@@ -9,7 +9,7 @@ namespace MqttClient {
 bool connect(const char* deviceId);
 
 /// Publish a reading to `combsense/hive/<deviceId>/reading`. Returns true on ack.
-bool publish(const char* deviceId, const Reading& r);
+bool publish(const char* deviceId, const Reading& r, int8_t rssi);
 
 /// Disconnect gracefully.
 void disconnect();

--- a/firmware/sensor-tag-wifi/src/ota.cpp
+++ b/firmware/sensor-tag-wifi/src/ota.cpp
@@ -1,0 +1,216 @@
+#include "ota.h"
+
+#include <Arduino.h>
+#include <Preferences.h>
+#include <esp_http_client.h>
+#include <esp_ota_ops.h>
+#include <cstring>
+
+#include "config.h"
+#include "ota_decision.h"
+#include "ota_manifest.h"
+#include "ota_sha256.h"
+#include "ota_state.h"
+
+#ifndef FIRMWARE_VERSION
+#define FIRMWARE_VERSION "unknown"
+#endif
+
+#ifndef OTA_VARIANT
+#define OTA_VARIANT "unknown"
+#endif
+
+namespace {
+
+void readOtaHost(char* out, size_t outCap) {
+    Preferences p;
+    p.begin(NVS_NAMESPACE, true);
+    String v = p.getString(NVS_KEY_OTA_HOST, OTA_DEFAULT_HOST);
+    p.end();
+    size_t n = v.length() < outCap ? v.length() : outCap - 1;
+    memcpy(out, v.c_str(), n);
+    out[n] = '\0';
+}
+
+bool fetchManifestText(const char* url, char* buf, size_t bufCap, int& outLen) {
+    esp_http_client_config_t cfg = {};
+    cfg.url        = url;
+    cfg.timeout_ms = OTA_HTTP_TIMEOUT_MS;
+
+    esp_http_client_handle_t client = esp_http_client_init(&cfg);
+    if (!client) return false;
+
+    bool ok = false;
+    if (esp_http_client_open(client, 0) == ESP_OK) {
+        esp_http_client_fetch_headers(client);
+        int total = 0;
+        while (total < (int)bufCap - 1) {
+            int n = esp_http_client_read(client, buf + total, (int)bufCap - 1 - total);
+            if (n < 0) { total = -1; break; }
+            if (n == 0) break;
+            total += n;
+        }
+        if (total >= 0) {
+            buf[total] = '\0';
+            outLen = total;
+            ok = (esp_http_client_get_status_code(client) == 200);
+        }
+        esp_http_client_close(client);
+    }
+    esp_http_client_cleanup(client);
+    return ok;
+}
+
+bool downloadAndStream(const Manifest& m, const esp_partition_t* target) {
+    esp_ota_handle_t handle = 0;
+    if (esp_ota_begin(target, OTA_WITH_SEQUENTIAL_WRITES, &handle) != ESP_OK) {
+        Serial.println("[OTA] esp_ota_begin failed");
+        return false;
+    }
+
+    esp_http_client_config_t cfg = {};
+    cfg.url        = m.url;
+    cfg.timeout_ms = OTA_HTTP_TIMEOUT_MS;
+    esp_http_client_handle_t client = esp_http_client_init(&cfg);
+    if (!client) { esp_ota_abort(handle); return false; }
+
+    bool ok = (esp_http_client_open(client, 0) == ESP_OK);
+    if (ok) esp_http_client_fetch_headers(client);
+
+    Sha256Streamer hasher;
+    uint8_t buf[1024];
+    size_t total = 0;
+    while (ok) {
+        int n = esp_http_client_read(client, reinterpret_cast<char*>(buf), sizeof(buf));
+        if (n < 0) { ok = false; break; }
+        if (n == 0) break;
+        if (esp_ota_write(handle, buf, n) != ESP_OK) { ok = false; break; }
+        hasher.update(buf, n);
+        total += n;
+    }
+
+    esp_http_client_close(client);
+    esp_http_client_cleanup(client);
+
+    if (!ok) {
+        Serial.printf("[OTA] download failed at %u bytes\n", (unsigned)total);
+        esp_ota_abort(handle);
+        return false;
+    }
+    if (total != m.size) {
+        Serial.printf("[OTA] size mismatch got=%u want=%u\n",
+                      (unsigned)total, (unsigned)m.size);
+        esp_ota_abort(handle);
+        return false;
+    }
+
+    char hex[65] = {};
+    hasher.finalizeToHex(hex);
+    if (!hasher.matches(m.sha256)) {
+        Serial.printf("[OTA] sha256 mismatch got=%s want=%s\n", hex, m.sha256);
+        esp_ota_abort(handle);
+        return false;
+    }
+
+    if (esp_ota_end(handle) != ESP_OK) {
+        Serial.println("[OTA] esp_ota_end failed");
+        return false;
+    }
+    Serial.printf("[OTA] download bytes=%u sha256_ok=true\n", (unsigned)total);
+    return true;
+}
+
+}  // namespace
+
+namespace Ota {
+
+void validateOnBoot() {
+    char attempted[32] = {};
+    OtaState::getAttempted(attempted, sizeof(attempted));
+
+    const esp_partition_t* running = esp_ota_get_running_partition();
+    esp_ota_img_states_t state = ESP_OTA_IMG_UNDEFINED;
+    bool isPending = false;
+    if (running && esp_ota_get_state_partition(running, &state) == ESP_OK) {
+        isPending = (state == ESP_OTA_IMG_PENDING_VERIFY);
+    }
+
+    ValidateAction action = validateOnBootAction(FIRMWARE_VERSION, attempted, isPending);
+    Serial.printf("[OTA] validate version=%s attempted=%s pending=%d action=%d\n",
+                  FIRMWARE_VERSION, attempted, (int)isPending, (int)action);
+
+    switch (action) {
+        case ValidateAction::NoOp:
+            break;
+        case ValidateAction::ClearAttempted:
+            OtaState::clearAttempted();
+            OtaState::clearFailed();
+            break;
+        case ValidateAction::RecordFailed:
+            OtaState::setFailed(attempted);
+            OtaState::clearAttempted();
+            break;
+    }
+}
+
+void onPublishSuccess() {
+    const esp_partition_t* running = esp_ota_get_running_partition();
+    esp_ota_img_states_t state = ESP_OTA_IMG_UNDEFINED;
+    if (!running || esp_ota_get_state_partition(running, &state) != ESP_OK) return;
+    if (state != ESP_OTA_IMG_PENDING_VERIFY) return;
+
+    Serial.println("[OTA] first publish ok — marking firmware valid");
+    esp_ota_mark_app_valid_cancel_rollback();
+    OtaState::clearAttempted();
+    OtaState::clearFailed();
+}
+
+void checkAndApply(uint8_t batteryPct) {
+    char host[64];
+    readOtaHost(host, sizeof(host));
+
+    char manifestUrl[160];
+    snprintf(manifestUrl, sizeof(manifestUrl),
+             "http://%s/firmware/sensor-tag-wifi/%s/manifest.json",
+             host, OTA_VARIANT);
+
+    char body[1024];
+    int len = 0;
+    if (!fetchManifestText(manifestUrl, body, sizeof(body), len)) {
+        Serial.println("[OTA] manifest fetch failed");
+        return;
+    }
+
+    Manifest m {};
+    if (!parseManifest(body, (size_t)len, m)) {
+        Serial.println("[OTA] manifest parse failed");
+        return;
+    }
+
+    char failed[32] = {};
+    OtaState::getFailed(failed, sizeof(failed));
+
+    Serial.printf("[OTA] check version=%s manifest=%s failed=%s battery=%u\n",
+                  FIRMWARE_VERSION, m.version, failed, batteryPct);
+
+    if (!shouldApply(FIRMWARE_VERSION, m.version, failed, batteryPct)) {
+        Serial.println("[OTA] check → skip");
+        return;
+    }
+
+    const esp_partition_t* target = esp_ota_get_next_update_partition(nullptr);
+    if (!target) { Serial.println("[OTA] no inactive partition"); return; }
+
+    if (!downloadAndStream(m, target)) return;
+
+    if (esp_ota_set_boot_partition(target) != ESP_OK) {
+        Serial.println("[OTA] set_boot_partition failed");
+        return;
+    }
+    OtaState::setAttempted(m.version);
+    Serial.printf("[OTA] reboot into %s\n", m.version);
+    Serial.flush();
+    esp_restart();
+}
+
+}  // namespace Ota

--- a/firmware/sensor-tag-wifi/src/ota.cpp
+++ b/firmware/sensor-tag-wifi/src/ota.cpp
@@ -177,7 +177,7 @@ void checkAndApply(uint8_t batteryPct) {
     char body[1024];
     int len = 0;
     if (!fetchManifestText(manifestUrl, body, sizeof(body), len)) {
-        Serial.println("[OTA] manifest fetch failed");
+        Serial.printf("[OTA] manifest fetch failed url=%s\n", manifestUrl);
         return;
     }
 

--- a/firmware/sensor-tag-wifi/src/ota.cpp
+++ b/firmware/sensor-tag-wifi/src/ota.cpp
@@ -72,7 +72,8 @@ bool parseHttpUrl(const char* url, UrlParts& out) {
 
 /// Open a raw HTTP/1.0 GET via WiFiClient. Bypasses esp-tls/getaddrinfo,
 /// which on ESP32-C6 routes through OpenThread DNS64 and fails for IPv4
-/// literals. PubSubClient uses the same WiFiClient path successfully.
+/// literals (EAI_FAIL/202). PubSubClient uses the same WiFiClient path
+/// successfully — this aligns OTA with that proven transport.
 bool openHttpGet(WiFiClient& client, const UrlParts& u) {
     IPAddress ip;
     if (!ip.fromString(u.host)) {

--- a/firmware/sensor-tag-wifi/src/ota.cpp
+++ b/firmware/sensor-tag-wifi/src/ota.cpp
@@ -2,9 +2,11 @@
 
 #include <Arduino.h>
 #include <Preferences.h>
-#include <esp_http_client.h>
+#include <WiFi.h>
+#include <WiFiClient.h>
 #include <esp_ota_ops.h>
 #include <cstring>
+#include <cstdlib>
 
 #include "config.h"
 #include "ota_decision.h"
@@ -32,71 +34,153 @@ void readOtaHost(char* out, size_t outCap) {
     out[n] = '\0';
 }
 
-bool fetchManifestText(const char* url, char* buf, size_t bufCap, int& outLen) {
-    esp_http_client_config_t cfg = {};
-    cfg.url        = url;
-    cfg.timeout_ms = OTA_HTTP_TIMEOUT_MS;
+struct UrlParts {
+    char     host[64];
+    uint16_t port;
+    char     path[160];
+};
 
-    esp_http_client_handle_t client = esp_http_client_init(&cfg);
-    if (!client) return false;
+/// Parse `http://host[:port]/path` into UrlParts. Bypassing DNS later
+/// requires the host as a separate string we can pass to IPAddress::fromString.
+bool parseHttpUrl(const char* url, UrlParts& out) {
+    if (strncmp(url, "http://", 7) != 0) return false;
+    const char* p     = url + 7;
+    const char* slash = strchr(p, '/');
+    const char* colon = strchr(p, ':');
 
-    bool ok = false;
-    if (esp_http_client_open(client, 0) == ESP_OK) {
-        esp_http_client_fetch_headers(client);
-        int total = 0;
-        while (total < (int)bufCap - 1) {
-            int n = esp_http_client_read(client, buf + total, (int)bufCap - 1 - total);
-            if (n < 0) { total = -1; break; }
-            if (n == 0) break;
-            total += n;
-        }
-        if (total >= 0) {
-            buf[total] = '\0';
-            outLen = total;
-            ok = (esp_http_client_get_status_code(client) == 200);
-        }
-        esp_http_client_close(client);
+    size_t hostLen;
+    if (colon && (!slash || colon < slash)) {
+        hostLen  = static_cast<size_t>(colon - p);
+        out.port = static_cast<uint16_t>(atoi(colon + 1));
+    } else {
+        hostLen  = slash ? static_cast<size_t>(slash - p) : strlen(p);
+        out.port = 80;
     }
-    esp_http_client_cleanup(client);
-    return ok;
+    if (hostLen == 0 || hostLen >= sizeof(out.host)) return false;
+    memcpy(out.host, p, hostLen);
+    out.host[hostLen] = '\0';
+
+    if (slash) {
+        size_t pathLen = strlen(slash);
+        if (pathLen >= sizeof(out.path)) return false;
+        memcpy(out.path, slash, pathLen + 1);
+    } else {
+        out.path[0] = '/'; out.path[1] = '\0';
+    }
+    return true;
+}
+
+/// Open a raw HTTP/1.0 GET via WiFiClient. Bypasses esp-tls/getaddrinfo,
+/// which on ESP32-C6 routes through OpenThread DNS64 and fails for IPv4
+/// literals. PubSubClient uses the same WiFiClient path successfully.
+bool openHttpGet(WiFiClient& client, const UrlParts& u) {
+    IPAddress ip;
+    if (!ip.fromString(u.host)) {
+        if (!WiFi.hostByName(u.host, ip)) return false;
+    }
+    client.setTimeout(OTA_HTTP_TIMEOUT_MS / 1000);
+    if (!client.connect(ip, u.port)) return false;
+    client.printf("GET %s HTTP/1.0\r\nHost: %s\r\nConnection: close\r\n\r\n",
+                  u.path, u.host);
+    return true;
+}
+
+/// Wait for client.available() up to OTA_HTTP_TIMEOUT_MS.
+bool waitForBytes(WiFiClient& client) {
+    uint32_t start = millis();
+    while (!client.available() && client.connected()) {
+        if (millis() - start > OTA_HTTP_TIMEOUT_MS) return false;
+        delay(10);
+    }
+    return client.available();
+}
+
+/// Read and discard HTTP headers; return true on 200 OK status line.
+bool readStatusAndDrainHeaders(WiFiClient& client) {
+    if (!waitForBytes(client)) return false;
+    String status = client.readStringUntil('\n');
+    if (status.indexOf(" 200 ") < 0) {
+        Serial.printf("[OTA] http status: %s\n", status.c_str());
+        return false;
+    }
+    while (client.connected() || client.available()) {
+        String line = client.readStringUntil('\n');
+        line.trim();
+        if (line.isEmpty()) return true;
+    }
+    return false;
+}
+
+bool fetchManifestText(const char* url, char* buf, size_t bufCap, int& outLen) {
+    UrlParts u;
+    if (!parseHttpUrl(url, u)) return false;
+
+    WiFiClient client;
+    if (!openHttpGet(client, u)) return false;
+    if (!readStatusAndDrainHeaders(client)) { client.stop(); return false; }
+
+    int total = 0;
+    while ((client.connected() || client.available()) && total < (int)bufCap - 1) {
+        if (client.available()) {
+            int n = client.read(reinterpret_cast<uint8_t*>(buf + total),
+                                bufCap - 1 - total);
+            if (n > 0) total += n;
+        } else {
+            delay(5);
+        }
+    }
+    client.stop();
+    buf[total] = '\0';
+    outLen     = total;
+    return total > 0;
 }
 
 bool downloadAndStream(const Manifest& m, const esp_partition_t* target) {
+    UrlParts u;
+    if (!parseHttpUrl(m.url, u)) {
+        Serial.printf("[OTA] bad url: %s\n", m.url);
+        return false;
+    }
+
     esp_ota_handle_t handle = 0;
     if (esp_ota_begin(target, OTA_WITH_SEQUENTIAL_WRITES, &handle) != ESP_OK) {
         Serial.println("[OTA] esp_ota_begin failed");
         return false;
     }
 
-    esp_http_client_config_t cfg = {};
-    cfg.url        = m.url;
-    cfg.timeout_ms = OTA_HTTP_TIMEOUT_MS;
-    esp_http_client_handle_t client = esp_http_client_init(&cfg);
-    if (!client) { esp_ota_abort(handle); return false; }
-
-    bool ok = (esp_http_client_open(client, 0) == ESP_OK);
-    if (ok) esp_http_client_fetch_headers(client);
-
-    Sha256Streamer hasher;
-    uint8_t buf[1024];
-    size_t total = 0;
-    while (ok) {
-        int n = esp_http_client_read(client, reinterpret_cast<char*>(buf), sizeof(buf));
-        if (n < 0) { ok = false; break; }
-        if (n == 0) break;
-        if (esp_ota_write(handle, buf, n) != ESP_OK) { ok = false; break; }
-        hasher.update(buf, n);
-        total += n;
-    }
-
-    esp_http_client_close(client);
-    esp_http_client_cleanup(client);
-
-    if (!ok) {
-        Serial.printf("[OTA] download failed at %u bytes\n", (unsigned)total);
+    WiFiClient client;
+    if (!openHttpGet(client, u)) {
+        Serial.println("[OTA] connect failed");
         esp_ota_abort(handle);
         return false;
     }
+    if (!readStatusAndDrainHeaders(client)) {
+        client.stop();
+        esp_ota_abort(handle);
+        return false;
+    }
+
+    Sha256Streamer hasher;
+    uint8_t buf[1024];
+    size_t  total = 0;
+    while (client.connected() || client.available()) {
+        if (client.available()) {
+            int n = client.read(buf, sizeof(buf));
+            if (n <= 0) continue;
+            if (esp_ota_write(handle, buf, n) != ESP_OK) {
+                Serial.printf("[OTA] write failed at %u bytes\n", (unsigned)total);
+                client.stop();
+                esp_ota_abort(handle);
+                return false;
+            }
+            hasher.update(buf, n);
+            total += n;
+        } else {
+            delay(5);
+        }
+    }
+    client.stop();
+
     if (total != m.size) {
         Serial.printf("[OTA] size mismatch got=%u want=%u\n",
                       (unsigned)total, (unsigned)m.size);

--- a/firmware/sensor-tag-wifi/src/ota_decision.cpp
+++ b/firmware/sensor-tag-wifi/src/ota_decision.cpp
@@ -1,0 +1,30 @@
+#include "ota_decision.h"
+
+#include <cstring>
+
+namespace {
+constexpr uint8_t BATTERY_FLOOR_PCT = 20;
+
+bool isEmpty(const char* s) { return s == nullptr || s[0] == '\0'; }
+}  // namespace
+
+bool shouldApply(const char* current,
+                 const char* manifest,
+                 const char* failed,
+                 uint8_t batteryPct) {
+    if (isEmpty(manifest)) return false;
+    if (!isEmpty(current) && strcmp(current, manifest) == 0) return false;
+    if (!isEmpty(failed) && strcmp(failed, manifest) == 0) return false;
+    if (batteryPct < BATTERY_FLOOR_PCT) return false;
+    return true;
+}
+
+ValidateAction validateOnBootAction(const char* firmwareVersion,
+                                    const char* attempted,
+                                    bool isPendingVerify) {
+    if (isEmpty(attempted)) return ValidateAction::NoOp;
+    if (strcmp(firmwareVersion, attempted) == 0) {
+        return isPendingVerify ? ValidateAction::NoOp : ValidateAction::ClearAttempted;
+    }
+    return ValidateAction::RecordFailed;
+}

--- a/firmware/sensor-tag-wifi/src/ota_manifest.cpp
+++ b/firmware/sensor-tag-wifi/src/ota_manifest.cpp
@@ -13,7 +13,10 @@ const char* findKey(const char* json, size_t len, const char* key) {
     if (n <= 0 || (size_t)n >= sizeof(needle)) return nullptr;
     const char* end = json + len;
     for (const char* p = json; p + n <= end; p++) {
-        if (memcmp(p, needle, n) == 0) return p + n;
+        if (memcmp(p, needle, n) != 0) continue;
+        const char* after = p + n;
+        while (after < end && isspace((unsigned char)*after)) after++;
+        if (after < end && *after == ':') return p + n;
     }
     return nullptr;
 }

--- a/firmware/sensor-tag-wifi/src/ota_manifest.cpp
+++ b/firmware/sensor-tag-wifi/src/ota_manifest.cpp
@@ -1,0 +1,70 @@
+#include "ota_manifest.h"
+
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <cctype>
+
+namespace {
+
+const char* findKey(const char* json, size_t len, const char* key) {
+    char needle[40];
+    int n = snprintf(needle, sizeof(needle), "\"%s\"", key);
+    if (n <= 0 || (size_t)n >= sizeof(needle)) return nullptr;
+    const char* end = json + len;
+    for (const char* p = json; p + n <= end; p++) {
+        if (memcmp(p, needle, n) == 0) return p + n;
+    }
+    return nullptr;
+}
+
+bool extractString(const char* json, size_t len, const char* key,
+                   char* out, size_t outCap) {
+    const char* p = findKey(json, len, key);
+    if (!p) return false;
+    const char* end = json + len;
+    while (p < end && *p != ':') p++;
+    if (p == end) return false;
+    p++;
+    while (p < end && isspace((unsigned char)*p)) p++;
+    if (p == end || *p != '"') return false;
+    p++;
+    const char* start = p;
+    while (p < end && *p != '"') p++;
+    if (p == end) return false;
+    size_t length = (size_t)(p - start);
+    if (length + 1 > outCap) return false;
+    memcpy(out, start, length);
+    out[length] = '\0';
+    return true;
+}
+
+bool extractNumber(const char* json, size_t len, const char* key, size_t& out) {
+    const char* p = findKey(json, len, key);
+    if (!p) return false;
+    const char* end = json + len;
+    while (p < end && *p != ':') p++;
+    if (p == end) return false;
+    p++;
+    while (p < end && isspace((unsigned char)*p)) p++;
+    if (p == end || !isdigit((unsigned char)*p)) return false;
+    char buf[24] = {};
+    size_t i = 0;
+    while (p < end && isdigit((unsigned char)*p) && i < sizeof(buf) - 1) {
+        buf[i++] = *p++;
+    }
+    out = (size_t)strtoul(buf, nullptr, 10);
+    return true;
+}
+
+}  // namespace
+
+bool parseManifest(const char* json, size_t len, Manifest& out) {
+    if (!json || len == 0) return false;
+    if (!extractString(json, len, "version", out.version, sizeof(out.version))) return false;
+    if (!extractString(json, len, "url",     out.url,     sizeof(out.url)))     return false;
+    if (!extractString(json, len, "sha256",  out.sha256,  sizeof(out.sha256)))  return false;
+    if (strlen(out.sha256) != 64) return false;
+    if (!extractNumber(json, len, "size", out.size)) return false;
+    return true;
+}

--- a/firmware/sensor-tag-wifi/src/ota_sha256.cpp
+++ b/firmware/sensor-tag-wifi/src/ota_sha256.cpp
@@ -59,9 +59,11 @@ void Sha256Streamer::update(const uint8_t* data, size_t len) {
 }
 void Sha256Streamer::finalizeToHex(char outHex[65]) {
     uint8_t raw[32];
-    static_cast<Backend*>(impl_)->finalize(raw);
+    Backend* backend = static_cast<Backend*>(impl_);
+    backend->finalize(raw);
     toHex(raw, outHex);
     memcpy(lastHex_, outHex, 65);
+    backend->reset();
 }
 bool Sha256Streamer::matches(const char* expectedHex) {
     if (lastHex_[0] == '\0') return false;

--- a/firmware/sensor-tag-wifi/src/ota_sha256.cpp
+++ b/firmware/sensor-tag-wifi/src/ota_sha256.cpp
@@ -1,0 +1,69 @@
+#include "ota_sha256.h"
+
+#include <cstring>
+#include <cctype>
+
+#ifdef ESP_PLATFORM
+#include "mbedtls/sha256.h"
+struct Backend {
+    mbedtls_sha256_context ctx;
+    Backend() { mbedtls_sha256_init(&ctx); mbedtls_sha256_starts(&ctx, 0); }
+    ~Backend() { mbedtls_sha256_free(&ctx); }
+    void reset() {
+        mbedtls_sha256_free(&ctx);
+        mbedtls_sha256_init(&ctx);
+        mbedtls_sha256_starts(&ctx, 0);
+    }
+    void update(const uint8_t* d, size_t n) { mbedtls_sha256_update(&ctx, d, n); }
+    void finalize(uint8_t out[32]) { mbedtls_sha256_finish(&ctx, out); }
+};
+#else
+#include "picosha2.h"
+struct Backend {
+    picosha2::hash256_one_by_one hasher;
+    Backend() { hasher.init(); }
+    void reset() { hasher.init(); }
+    void update(const uint8_t* d, size_t n) { hasher.process(d, d + n); }
+    void finalize(uint8_t out[32]) {
+        hasher.finish();
+        hasher.get_hash_bytes(out, out + 32);
+    }
+};
+#endif
+
+namespace {
+void toHex(const uint8_t in[32], char out[65]) {
+    static const char* lut = "0123456789abcdef";
+    for (size_t i = 0; i < 32; i++) {
+        out[2 * i]     = lut[in[i] >> 4];
+        out[2 * i + 1] = lut[in[i] & 0x0f];
+    }
+    out[64] = '\0';
+}
+
+bool hexEqIgnoreCase(const char* a, const char* b) {
+    while (*a && *b) {
+        if (tolower((unsigned char)*a) != tolower((unsigned char)*b)) return false;
+        a++; b++;
+    }
+    return *a == '\0' && *b == '\0';
+}
+}  // namespace
+
+Sha256Streamer::Sha256Streamer() : impl_(new Backend()) { lastHex_[0] = '\0'; }
+Sha256Streamer::~Sha256Streamer() { delete static_cast<Backend*>(impl_); }
+
+void Sha256Streamer::reset() { static_cast<Backend*>(impl_)->reset(); lastHex_[0] = '\0'; }
+void Sha256Streamer::update(const uint8_t* data, size_t len) {
+    static_cast<Backend*>(impl_)->update(data, len);
+}
+void Sha256Streamer::finalizeToHex(char outHex[65]) {
+    uint8_t raw[32];
+    static_cast<Backend*>(impl_)->finalize(raw);
+    toHex(raw, outHex);
+    memcpy(lastHex_, outHex, 65);
+}
+bool Sha256Streamer::matches(const char* expectedHex) {
+    if (lastHex_[0] == '\0') return false;
+    return hexEqIgnoreCase(lastHex_, expectedHex);
+}

--- a/firmware/sensor-tag-wifi/src/ota_state.cpp
+++ b/firmware/sensor-tag-wifi/src/ota_state.cpp
@@ -1,0 +1,46 @@
+#include "ota_state.h"
+
+#include <Preferences.h>
+#include <cstring>
+
+namespace {
+constexpr const char* OTA_NS      = "ota";
+constexpr const char* K_ATTEMPTED = "attempted";
+constexpr const char* K_FAILED    = "failed";
+
+void readKey(const char* key, char* out, size_t outCap) {
+    Preferences p;
+    p.begin(OTA_NS, true);
+    String v = p.getString(key, "");
+    p.end();
+    size_t n = v.length() < outCap ? v.length() : outCap - 1;
+    memcpy(out, v.c_str(), n);
+    out[n] = '\0';
+}
+
+void writeKey(const char* key, const char* value) {
+    Preferences p;
+    p.begin(OTA_NS, false);
+    p.putString(key, value);
+    p.end();
+}
+
+void removeKey(const char* key) {
+    Preferences p;
+    p.begin(OTA_NS, false);
+    p.remove(key);
+    p.end();
+}
+}  // namespace
+
+namespace OtaState {
+
+void getAttempted(char* out, size_t outCap) { readKey(K_ATTEMPTED, out, outCap); }
+void setAttempted(const char* v)            { writeKey(K_ATTEMPTED, v); }
+void clearAttempted()                       { removeKey(K_ATTEMPTED); }
+
+void getFailed(char* out, size_t outCap)    { readKey(K_FAILED, out, outCap); }
+void setFailed(const char* v)               { writeKey(K_FAILED, v); }
+void clearFailed()                          { removeKey(K_FAILED); }
+
+}  // namespace OtaState

--- a/firmware/sensor-tag-wifi/src/payload.cpp
+++ b/firmware/sensor-tag-wifi/src/payload.cpp
@@ -26,18 +26,26 @@ static bool appendNumOrNull(char*& p, char* end, const char* key, float v) {
     return appendf(p, end, ",\"%s\":%.2f", key, v);
 }
 
-int serialize(const char* deviceId, const Reading& r, char* buf, size_t bufLen) {
+int serialize(const char* deviceId,
+              const char* fwVersion,
+              int8_t      rssi,
+              const Reading& r,
+              char* buf, size_t bufLen) {
     if (bufLen == 0) return -1;
     char* p   = buf;
     char* end = buf + bufLen;
 
-    if (!appendf(p, end, "{\"id\":\"%s\",\"t\":%lu",
-                 deviceId, static_cast<unsigned long>(r.timestamp))) return -1;
+    if (!appendf(p, end, "{\"id\":\"%s\",\"v\":\"%s\",\"t\":%lu",
+                 deviceId, fwVersion,
+                 static_cast<unsigned long>(r.timestamp))) return -1;
     if (!appendNumOrNull(p, end, "t1", r.temp1)) return -1;
     if (!appendNumOrNull(p, end, "t2", r.temp2)) return -1;
     if (!std::isnan(r.humidity1) && !appendf(p, end, ",\"h1\":%.2f", r.humidity1)) return -1;
     if (!std::isnan(r.humidity2) && !appendf(p, end, ",\"h2\":%.2f", r.humidity2)) return -1;
-    if (!appendf(p, end, ",\"b\":%u}", r.battery_pct)) return -1;
+    if (!appendf(p, end, ",\"vbat_mV\":%u,\"rssi\":%d,\"b\":%u}",
+                 static_cast<unsigned>(r.vbat_mV),
+                 static_cast<int>(rssi),
+                 static_cast<unsigned>(r.battery_pct))) return -1;
 
     return static_cast<int>(p - buf);
 }

--- a/firmware/sensor-tag-wifi/src/ring_buffer.cpp
+++ b/firmware/sensor-tag-wifi/src/ring_buffer.cpp
@@ -13,7 +13,7 @@ RTC_DATA_ATTR uint8_t  rtcHead  = 0;    // write index
 RTC_DATA_ATTR uint8_t  rtcCount = 0;
 RTC_DATA_ATTR Reading  rtcBuf[RTC_BUFFER_CAPACITY];
 
-constexpr uint32_t MAGIC = 0xCB50A001u;  // "CombSense Tag Wi-Fi"
+constexpr uint32_t MAGIC = 0xCB50A002u;  // bumped 2026-04-25: Reading layout grew vbat_mV — old slots invalid
 
 }  // anonymous namespace
 

--- a/firmware/sensor-tag-wifi/test/test_battery_math/test_battery_math.cpp
+++ b/firmware/sensor-tag-wifi/test/test_battery_math/test_battery_math.cpp
@@ -1,0 +1,42 @@
+#include <unity.h>
+#include "battery.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_full_voltage_returns_100() {
+    TEST_ASSERT_EQUAL_UINT8(100, Battery::percentFromMillivolts(4200));
+}
+
+void test_above_full_clamps_to_100() {
+    TEST_ASSERT_EQUAL_UINT8(100, Battery::percentFromMillivolts(4500));
+}
+
+void test_empty_voltage_returns_0() {
+    TEST_ASSERT_EQUAL_UINT8(0, Battery::percentFromMillivolts(3300));
+}
+
+void test_below_empty_clamps_to_0() {
+    TEST_ASSERT_EQUAL_UINT8(0, Battery::percentFromMillivolts(3100));
+}
+
+void test_midpoint_returns_50() {
+    // (3750 - 3300) * 100 / (4200 - 3300) = 45000/900 = 50
+    TEST_ASSERT_EQUAL_UINT8(50, Battery::percentFromMillivolts(3750));
+}
+
+void test_three_quarters_returns_75() {
+    // (3975 - 3300) * 100 / 900 = 67500/900 = 75
+    TEST_ASSERT_EQUAL_UINT8(75, Battery::percentFromMillivolts(3975));
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_full_voltage_returns_100);
+    RUN_TEST(test_above_full_clamps_to_100);
+    RUN_TEST(test_empty_voltage_returns_0);
+    RUN_TEST(test_below_empty_clamps_to_0);
+    RUN_TEST(test_midpoint_returns_50);
+    RUN_TEST(test_three_quarters_returns_75);
+    return UNITY_END();
+}

--- a/firmware/sensor-tag-wifi/test/test_battery_math/test_battery_math.cpp
+++ b/firmware/sensor-tag-wifi/test/test_battery_math/test_battery_math.cpp
@@ -30,6 +30,11 @@ void test_three_quarters_returns_75() {
     TEST_ASSERT_EQUAL_UINT8(75, Battery::percentFromMillivolts(3975));
 }
 
+void test_percent_from_millivolts_truncates_not_rounds() {
+    // (3314 - 3300) * 100.0 / 900 = 1400/900 = 1.555...; floor=1, round-half-up=2
+    TEST_ASSERT_EQUAL_UINT8(1, Battery::percentFromMillivolts(3314));
+}
+
 int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_full_voltage_returns_100);
@@ -38,5 +43,6 @@ int main(int, char**) {
     RUN_TEST(test_below_empty_clamps_to_0);
     RUN_TEST(test_midpoint_returns_50);
     RUN_TEST(test_three_quarters_returns_75);
+    RUN_TEST(test_percent_from_millivolts_truncates_not_rounds);
     return UNITY_END();
 }

--- a/firmware/sensor-tag-wifi/test/test_ota_decision/test_ota_decision.cpp
+++ b/firmware/sensor-tag-wifi/test/test_ota_decision/test_ota_decision.cpp
@@ -1,0 +1,41 @@
+#include <unity.h>
+#include "ota_decision.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_skip_when_versions_match() {
+    TEST_ASSERT_FALSE(shouldApply("v0.2.0", "v0.2.0", "", 100));
+}
+
+void test_skip_when_manifest_matches_failed() {
+    TEST_ASSERT_FALSE(shouldApply("v0.2.0", "v0.3.0", "v0.3.0", 100));
+}
+
+void test_skip_when_battery_below_floor() {
+    TEST_ASSERT_FALSE(shouldApply("v0.2.0", "v0.3.0", "", 19));
+}
+
+void test_apply_when_new_version_and_healthy_battery() {
+    TEST_ASSERT_TRUE(shouldApply("v0.2.0", "v0.3.0", "", 20));
+    TEST_ASSERT_TRUE(shouldApply("v0.2.0", "v0.3.0", "", 100));
+}
+
+void test_apply_when_failed_is_different_version() {
+    TEST_ASSERT_TRUE(shouldApply("v0.2.0", "v0.3.0", "v0.2.5", 80));
+}
+
+void test_skip_when_manifest_empty() {
+    TEST_ASSERT_FALSE(shouldApply("v0.2.0", "", "", 100));
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_skip_when_versions_match);
+    RUN_TEST(test_skip_when_manifest_matches_failed);
+    RUN_TEST(test_skip_when_battery_below_floor);
+    RUN_TEST(test_apply_when_new_version_and_healthy_battery);
+    RUN_TEST(test_apply_when_failed_is_different_version);
+    RUN_TEST(test_skip_when_manifest_empty);
+    return UNITY_END();
+}

--- a/firmware/sensor-tag-wifi/test/test_ota_manifest/test_ota_manifest.cpp
+++ b/firmware/sensor-tag-wifi/test/test_ota_manifest/test_ota_manifest.cpp
@@ -1,0 +1,66 @@
+#include <unity.h>
+#include <cstring>
+#include <cstdio>
+#include "ota_manifest.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_parses_valid_manifest() {
+    const char* j =
+        "{\"version\":\"v0.2.0\","
+        "\"url\":\"http://192.168.1.61/firmware/sensor-tag-wifi/sht31/v0.2.0/firmware.bin\","
+        "\"sha256\":\"abc123def456abc123def456abc123def456abc123def456abc123def4561234\","
+        "\"size\":1046912}";
+    Manifest m {};
+    TEST_ASSERT_TRUE(parseManifest(j, strlen(j), m));
+    TEST_ASSERT_EQUAL_STRING("v0.2.0", m.version);
+    TEST_ASSERT_EQUAL_STRING(
+        "http://192.168.1.61/firmware/sensor-tag-wifi/sht31/v0.2.0/firmware.bin", m.url);
+    TEST_ASSERT_EQUAL_STRING(
+        "abc123def456abc123def456abc123def456abc123def456abc123def4561234", m.sha256);
+    TEST_ASSERT_EQUAL_UINT32(1046912, m.size);
+}
+
+void test_rejects_missing_field() {
+    const char* j = "{\"version\":\"v0.2.0\",\"url\":\"http://x/y\",\"size\":100}";
+    Manifest m {};
+    TEST_ASSERT_FALSE(parseManifest(j, strlen(j), m));
+}
+
+void test_rejects_malformed_json() {
+    const char* j = "{not valid json";
+    Manifest m {};
+    TEST_ASSERT_FALSE(parseManifest(j, strlen(j), m));
+}
+
+void test_rejects_oversize_url() {
+    char j[600];
+    char url[300];
+    memset(url, 'a', sizeof(url) - 1);
+    url[sizeof(url) - 1] = '\0';
+    snprintf(j, sizeof(j),
+        "{\"version\":\"v1\",\"url\":\"%s\",\"sha256\":\"%s\",\"size\":1}",
+        url,
+        "0000000000000000000000000000000000000000000000000000000000000000");
+    Manifest m {};
+    TEST_ASSERT_FALSE(parseManifest(j, strlen(j), m));
+}
+
+void test_rejects_wrong_sha_length() {
+    const char* j =
+        "{\"version\":\"v1\",\"url\":\"http://x/y\","
+        "\"sha256\":\"deadbeef\",\"size\":1}";
+    Manifest m {};
+    TEST_ASSERT_FALSE(parseManifest(j, strlen(j), m));
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_parses_valid_manifest);
+    RUN_TEST(test_rejects_missing_field);
+    RUN_TEST(test_rejects_malformed_json);
+    RUN_TEST(test_rejects_oversize_url);
+    RUN_TEST(test_rejects_wrong_sha_length);
+    return UNITY_END();
+}

--- a/firmware/sensor-tag-wifi/test/test_ota_manifest/test_ota_manifest.cpp
+++ b/firmware/sensor-tag-wifi/test/test_ota_manifest/test_ota_manifest.cpp
@@ -55,6 +55,48 @@ void test_rejects_wrong_sha_length() {
     TEST_ASSERT_FALSE(parseManifest(j, strlen(j), m));
 }
 
+void test_key_substring_in_url_value_does_not_false_match() {
+    // The URL contains "sha256" as a path segment. The parser must not match
+    // it as the sha256 key — the real key is later in the document.
+    const char* j =
+        "{\"version\":\"v1\","
+        "\"url\":\"http://host/sha256/fw.bin\","
+        "\"sha256\":\"0000000000000000000000000000000000000000000000000000000000000000\","
+        "\"size\":1}";
+    Manifest m {};
+    TEST_ASSERT_TRUE(parseManifest(j, strlen(j), m));
+    TEST_ASSERT_EQUAL_STRING("v1", m.version);
+    TEST_ASSERT_EQUAL_STRING("http://host/sha256/fw.bin", m.url);
+    TEST_ASSERT_EQUAL_STRING(
+        "0000000000000000000000000000000000000000000000000000000000000000", m.sha256);
+}
+
+void test_rejects_truncated_after_first_field() {
+    // findKey hits "version" but extractString fails for url because the
+    // document terminates before the next quoted value.
+    const char* j = "{\"version\":\"v1\"";
+    Manifest m {};
+    TEST_ASSERT_FALSE(parseManifest(j, strlen(j), m));
+}
+
+void test_rejects_colon_with_no_value() {
+    // findKey hits "url" but the value isn't a string literal — exercises
+    // the "*p != '\"'" guard in extractString.
+    const char* j = "{\"version\":\"v1\",\"url\":";
+    Manifest m {};
+    TEST_ASSERT_FALSE(parseManifest(j, strlen(j), m));
+}
+
+void test_rejects_non_numeric_size() {
+    const char* j =
+        "{\"version\":\"v1\","
+        "\"url\":\"http://x/y\","
+        "\"sha256\":\"0000000000000000000000000000000000000000000000000000000000000000\","
+        "\"size\":\"oops\"}";
+    Manifest m {};
+    TEST_ASSERT_FALSE(parseManifest(j, strlen(j), m));
+}
+
 int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_parses_valid_manifest);
@@ -62,5 +104,9 @@ int main(int, char**) {
     RUN_TEST(test_rejects_malformed_json);
     RUN_TEST(test_rejects_oversize_url);
     RUN_TEST(test_rejects_wrong_sha_length);
+    RUN_TEST(test_key_substring_in_url_value_does_not_false_match);
+    RUN_TEST(test_rejects_truncated_after_first_field);
+    RUN_TEST(test_rejects_colon_with_no_value);
+    RUN_TEST(test_rejects_non_numeric_size);
     return UNITY_END();
 }

--- a/firmware/sensor-tag-wifi/test/test_ota_sha256/test_ota_sha256.cpp
+++ b/firmware/sensor-tag-wifi/test/test_ota_sha256/test_ota_sha256.cpp
@@ -1,0 +1,71 @@
+#include <unity.h>
+#include <cstring>
+#include "ota_sha256.h"
+
+void setUp() {}
+void tearDown() {}
+
+// Known SHA-256 fixtures
+// "" -> e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+// "abc" -> ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+
+void test_empty_input_hash() {
+    Sha256Streamer s;
+    char hex[65] = {};
+    s.finalizeToHex(hex);
+    TEST_ASSERT_EQUAL_STRING(
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hex);
+}
+
+void test_single_chunk_abc() {
+    Sha256Streamer s;
+    s.update(reinterpret_cast<const uint8_t*>("abc"), 3);
+    char hex[65] = {};
+    s.finalizeToHex(hex);
+    TEST_ASSERT_EQUAL_STRING(
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", hex);
+}
+
+void test_streaming_matches_single_chunk() {
+    Sha256Streamer s;
+    s.update(reinterpret_cast<const uint8_t*>("a"), 1);
+    s.update(reinterpret_cast<const uint8_t*>("b"), 1);
+    s.update(reinterpret_cast<const uint8_t*>("c"), 1);
+    char hex[65] = {};
+    s.finalizeToHex(hex);
+    TEST_ASSERT_EQUAL_STRING(
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", hex);
+}
+
+void test_matches_compares_case_insensitive() {
+    Sha256Streamer s;
+    s.update(reinterpret_cast<const uint8_t*>("abc"), 3);
+    char hex[65] = {};
+    s.finalizeToHex(hex);
+    TEST_ASSERT_TRUE(s.matches(
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"));
+    TEST_ASSERT_TRUE(s.matches(
+        "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD"));
+    TEST_ASSERT_FALSE(s.matches("0000000000000000000000000000000000000000000000000000000000000000"));
+}
+
+void test_reset_allows_reuse() {
+    Sha256Streamer s;
+    s.update(reinterpret_cast<const uint8_t*>("ignored"), 7);
+    s.reset();
+    s.update(reinterpret_cast<const uint8_t*>("abc"), 3);
+    char hex[65] = {};
+    s.finalizeToHex(hex);
+    TEST_ASSERT_EQUAL_STRING(
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", hex);
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_empty_input_hash);
+    RUN_TEST(test_single_chunk_abc);
+    RUN_TEST(test_streaming_matches_single_chunk);
+    RUN_TEST(test_matches_compares_case_insensitive);
+    RUN_TEST(test_reset_allows_reuse);
+    return UNITY_END();
+}

--- a/firmware/sensor-tag-wifi/test/test_ota_validation/test_ota_validation.cpp
+++ b/firmware/sensor-tag-wifi/test/test_ota_validation/test_ota_validation.cpp
@@ -1,0 +1,36 @@
+#include <unity.h>
+#include "ota_decision.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_noop_when_attempted_empty() {
+    TEST_ASSERT_TRUE(validateOnBootAction("v0.2.0", "", false) == ValidateAction::NoOp);
+    TEST_ASSERT_TRUE(validateOnBootAction("v0.2.0", "", true)  == ValidateAction::NoOp);
+}
+
+void test_noop_when_pending_and_versions_match() {
+    TEST_ASSERT_TRUE(
+        validateOnBootAction("v0.3.0", "v0.3.0", true) == ValidateAction::NoOp);
+}
+
+void test_clear_attempted_when_already_validated() {
+    TEST_ASSERT_TRUE(
+        validateOnBootAction("v0.3.0", "v0.3.0", false) == ValidateAction::ClearAttempted);
+}
+
+void test_record_failed_when_running_old_firmware_after_attempt() {
+    TEST_ASSERT_TRUE(
+        validateOnBootAction("v0.2.0", "v0.3.0", false) == ValidateAction::RecordFailed);
+    TEST_ASSERT_TRUE(
+        validateOnBootAction("v0.2.0", "v0.3.0", true)  == ValidateAction::RecordFailed);
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_noop_when_attempted_empty);
+    RUN_TEST(test_noop_when_pending_and_versions_match);
+    RUN_TEST(test_clear_attempted_when_already_validated);
+    RUN_TEST(test_record_failed_when_running_old_firmware_after_attempt);
+    return UNITY_END();
+}

--- a/firmware/sensor-tag-wifi/test/test_payload/test_payload.cpp
+++ b/firmware/sensor-tag-wifi/test/test_payload/test_payload.cpp
@@ -1,5 +1,6 @@
 #include <unity.h>
 #include <cstring>
+#include <cmath>
 #include "reading.h"
 #include "payload.h"
 
@@ -13,14 +14,16 @@ void test_serialize_full_reading_with_humidity() {
         .temp2 = 24.1f,
         .humidity1 = 52.3f,
         .humidity2 = 55.1f,
+        .vbat_mV = 3987,
         .battery_pct = 87,
     };
-    char buf[160];
-    int n = Payload::serialize("ab12cd34", r, buf, sizeof(buf));
+    char buf[200];
+    int n = Payload::serialize("ab12cd34", "5423c04", -58, r, buf, sizeof(buf));
     TEST_ASSERT_GREATER_THAN(0, n);
     TEST_ASSERT_EQUAL_STRING(
-        "{\"id\":\"ab12cd34\",\"t\":1712345678,\"t1\":22.40,\"t2\":24.10,"
-        "\"h1\":52.30,\"h2\":55.10,\"b\":87}",
+        "{\"id\":\"ab12cd34\",\"v\":\"5423c04\",\"t\":1712345678,"
+        "\"t1\":22.40,\"t2\":24.10,\"h1\":52.30,\"h2\":55.10,"
+        "\"vbat_mV\":3987,\"rssi\":-58,\"b\":87}",
         buf);
 }
 
@@ -31,13 +34,15 @@ void test_serialize_ds18b20_reading_omits_humidity() {
         .temp2 = 24.1f,
         .humidity1 = NAN,
         .humidity2 = NAN,
+        .vbat_mV = 3987,
         .battery_pct = 87,
     };
-    char buf[160];
-    int n = Payload::serialize("ab12cd34", r, buf, sizeof(buf));
+    char buf[200];
+    int n = Payload::serialize("ab12cd34", "5423c04", -58, r, buf, sizeof(buf));
     TEST_ASSERT_GREATER_THAN(0, n);
     TEST_ASSERT_EQUAL_STRING(
-        "{\"id\":\"ab12cd34\",\"t\":1712345678,\"t1\":22.40,\"t2\":24.10,\"b\":87}",
+        "{\"id\":\"ab12cd34\",\"v\":\"5423c04\",\"t\":1712345678,"
+        "\"t1\":22.40,\"t2\":24.10,\"vbat_mV\":3987,\"rssi\":-58,\"b\":87}",
         buf);
 }
 
@@ -46,10 +51,11 @@ void test_serialize_returns_negative_on_undersized_buffer() {
         .timestamp = 1712345678,
         .temp1 = 22.4f, .temp2 = 24.1f,
         .humidity1 = 52.3f, .humidity2 = 55.1f,
+        .vbat_mV = 3987,
         .battery_pct = 87,
     };
     char buf[8];
-    int n = Payload::serialize("ab12cd34", r, buf, sizeof(buf));
+    int n = Payload::serialize("ab12cd34", "5423c04", -58, r, buf, sizeof(buf));
     TEST_ASSERT_LESS_THAN(0, n);
 }
 
@@ -60,14 +66,16 @@ void test_serialize_emits_only_valid_humidity_channel() {
         .temp2 = 24.1f,
         .humidity1 = 52.3f,
         .humidity2 = NAN,      // top SHT31 failed
+        .vbat_mV = 3987,
         .battery_pct = 87,
     };
-    char buf[160];
-    int n = Payload::serialize("ab12cd34", r, buf, sizeof(buf));
+    char buf[200];
+    int n = Payload::serialize("ab12cd34", "5423c04", -58, r, buf, sizeof(buf));
     TEST_ASSERT_GREATER_THAN(0, n);
     TEST_ASSERT_EQUAL_STRING(
-        "{\"id\":\"ab12cd34\",\"t\":1712345678,\"t1\":22.40,\"t2\":24.10,"
-        "\"h1\":52.30,\"b\":87}",
+        "{\"id\":\"ab12cd34\",\"v\":\"5423c04\",\"t\":1712345678,"
+        "\"t1\":22.40,\"t2\":24.10,\"h1\":52.30,"
+        "\"vbat_mV\":3987,\"rssi\":-58,\"b\":87}",
         buf);
 }
 
@@ -80,13 +88,15 @@ void test_serialize_emits_null_for_nan_temps() {
         .temp2 = NAN,           // external DS18B20 not wired
         .humidity1 = NAN,
         .humidity2 = NAN,
+        .vbat_mV = 0,
         .battery_pct = 0,
     };
-    char buf[160];
-    int n = Payload::serialize("c5fffe12", r, buf, sizeof(buf));
+    char buf[200];
+    int n = Payload::serialize("c5fffe12", "5423c04", -58, r, buf, sizeof(buf));
     TEST_ASSERT_GREATER_THAN(0, n);
     TEST_ASSERT_EQUAL_STRING(
-        "{\"id\":\"c5fffe12\",\"t\":1712345678,\"t1\":21.50,\"t2\":null,\"b\":0}",
+        "{\"id\":\"c5fffe12\",\"v\":\"5423c04\",\"t\":1712345678,"
+        "\"t1\":21.50,\"t2\":null,\"vbat_mV\":0,\"rssi\":-58,\"b\":0}",
         buf);
 }
 
@@ -101,12 +111,32 @@ void test_serialize_emits_t_zero_when_timestamp_unset() {
         .temp2 = 21.00f,
         .humidity1 = NAN,
         .humidity2 = NAN,
+        .vbat_mV = 3987,
         .battery_pct = 50,
     };
-    char buf[160];
-    int n = Payload::serialize("ab12cd34", r, buf, sizeof(buf));
+    char buf[200];
+    int n = Payload::serialize("ab12cd34", "5423c04", -58, r, buf, sizeof(buf));
     TEST_ASSERT_GREATER_THAN(0, n);
     TEST_ASSERT_NOT_NULL(strstr(buf, "\"t\":0,"));
+}
+
+void test_serialize_with_unknown_version() {
+    // get_version.py falls back to the literal "unknown" when git describe
+    // fails. The payload must carry that string verbatim so the operator can
+    // still distinguish a no-git build from a real version.
+    Reading r {
+        .timestamp = 1712345678,
+        .temp1 = 22.4f,
+        .temp2 = 24.1f,
+        .humidity1 = NAN,
+        .humidity2 = NAN,
+        .vbat_mV = 3987,
+        .battery_pct = 87,
+    };
+    char buf[200];
+    int n = Payload::serialize("ab12cd34", "unknown", -58, r, buf, sizeof(buf));
+    TEST_ASSERT_GREATER_THAN(0, n);
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"v\":\"unknown\""));
 }
 
 int main(int, char**) {
@@ -117,5 +147,6 @@ int main(int, char**) {
     RUN_TEST(test_serialize_emits_only_valid_humidity_channel);
     RUN_TEST(test_serialize_emits_null_for_nan_temps);
     RUN_TEST(test_serialize_emits_t_zero_when_timestamp_unset);
+    RUN_TEST(test_serialize_with_unknown_version);
     return UNITY_END();
 }

--- a/firmware/shared/serial_console.cpp
+++ b/firmware/shared/serial_console.cpp
@@ -15,7 +15,8 @@ const char* knownKeys[] = {
     "weight_off", "weight_scl", "mqtt_host", "mqtt_port", "mqtt_user", "mqtt_pass",
     "tag_name", "tag_name_2", "adv_interval",
     "wifi_ssid", "wifi_pass",
-    "sample_int", "upload_every"
+    "sample_int", "upload_every",
+    "ota_host"
 };
 constexpr uint8_t NUM_KNOWN_KEYS = sizeof(knownKeys) / sizeof(knownKeys[0]);
 

--- a/tools/provision_tag.py
+++ b/tools/provision_tag.py
@@ -1,34 +1,51 @@
 #!/usr/bin/env python3
-"""Provision a sensor-tag-wifi via its 3-second serial console window.
+"""Provision a sensor-tag-wifi via its serial console.
 
-Waits for the C6's USB CDC to appear, then sends a keypress to enter the
-console when it sees the prompt line, writes WiFi/MQTT creds, and exits
-back to normal operation.
+Waits for the C6's USB CDC to appear, sends provisioning commands over the
+console, then exits. Override defaults via CLI flags.
 """
+import argparse
+import glob
 import sys
 import time
-import glob
 import serial
 
 
 PORT_GLOB = "/dev/cu.usbmodem*"
 BAUD = 115200
-PROMPT_LINE = b"[CONSOLE]"
 SHELL_PROMPT = b"> "
 
-COMMANDS = [
-    "set wifi_ssid IOT",
-    "set wifi_pass 4696930759",
-    "set mqtt_host 192.168.1.82",
-    "set mqtt_port 1883",
-    "set mqtt_user hivesense",
-    "set mqtt_pass hivesense",
-    "set tag_name bench-ds18b20",
-    "set sample_int 30",
-    "set upload_every 1",
-    "list",
-    "exit",
-]
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--wifi-ssid", default="IOT")
+    p.add_argument("--wifi-pass", default="4696930759")
+    p.add_argument("--mqtt-host", default="192.168.1.82")
+    p.add_argument("--mqtt-port", default="1883")
+    p.add_argument("--mqtt-user", default="hivesense")
+    p.add_argument("--mqtt-pass", default="hivesense")
+    p.add_argument("--tag-name",  default="bench-ds18b20")
+    p.add_argument("--sample-int", default="30")
+    p.add_argument("--upload-every", default="1")
+    p.add_argument("--ota-host",  default="192.168.1.61")
+    return p.parse_args()
+
+
+def build_commands(a: argparse.Namespace) -> list[str]:
+    return [
+        f"set wifi_ssid {a.wifi_ssid}",
+        f"set wifi_pass {a.wifi_pass}",
+        f"set mqtt_host {a.mqtt_host}",
+        f"set mqtt_port {a.mqtt_port}",
+        f"set mqtt_user {a.mqtt_user}",
+        f"set mqtt_pass {a.mqtt_pass}",
+        f"set tag_name {a.tag_name}",
+        f"set sample_int {a.sample_int}",
+        f"set upload_every {a.upload_every}",
+        f"set ota_host {a.ota_host}",
+        "list",
+        "exit",
+    ]
 
 
 def find_port(timeout_s: float = 60.0) -> str:
@@ -89,18 +106,18 @@ def drain(ser: serial.Serial, duration_s: float) -> None:
 
 
 def main() -> None:
+    args = parse_args()
+    commands = build_commands(args)
+
     port = find_port()
     with open_serial(port) as ser:
         print("[prov] opened — probing for console")
-        # Send a harmless command to force the console to emit a fresh prompt.
-        # We may be mid-readLine from a previous session, so a bare newline
-        # wouldn't break out of the readLine skip-empty-lines path.
         ser.write(b"help\r")
         if not wait_for(ser, SHELL_PROMPT, timeout_s=5.0):
             print("\n[prov] no shell prompt — reconnect the C6 and retry")
             return
 
-        for cmd in COMMANDS:
+        for cmd in commands:
             print(f"\n[prov] >> {cmd}")
             ser.write(cmd.encode() + b"\r")
             wait_for(ser, SHELL_PROMPT, timeout_s=3.0)


### PR DESCRIPTION
## Summary
- **Fleet visibility** — sensor-tag-wifi reading payload now carries firmware version (`v`), raw battery voltage (`vbat_mV`), and WiFi RSSI (`rssi`) alongside the existing battery percent. Live on yard tag `c5fffe12`.
- **HTTP-pull OTA** — manifest-driven, sha256-verified, dual-slot, validate-on-boot. Manifest published from build host via `deploy/web/publish-firmware.sh <variant>`.
- **ESP32-S3-Zero port** — Waveshare S3-Zero variant of sensor-tag-wifi, with ds18b20 + s3-ds18b20 build envs.
- **TSDB / Grafana** — Telegraf json_v2 now parses the new fields into Influx; `home-yard-sensors` dashboard gained RSSI / vbat_mV / fw_version panels and is now actually file-provisioned on the LXC.
- **Battery refactor** — `Battery::readPercent` split into `readMillivolts()` (Arduino) + `percentFromMillivolts()` (pure, unit-tested 38 native tests).

## Design / plan docs
- `docs/superpowers/specs/2026-04-25-sensor-tag-wifi-fleet-visibility-design.md`
- `docs/superpowers/plans/2026-04-25-sensor-tag-wifi-fleet-visibility.md`
- `docs/superpowers/specs/2026-04-23-sensor-tag-wifi-ota-design.md`
- `docs/superpowers/plans/2026-04-23-sensor-tag-wifi-ota.md`

## Test plan
- [x] 38 native unit tests pass (`pio test -e native`)
- [x] Arduino build green for all sensor-tag-wifi envs (sht31, ds18b20, s3-ds18b20)
- [x] OTA pipeline verified end-to-end on yard tag `c5fffe12` (boot banner shows `beaf768`, MQTT reading carries `v=beaf768, vbat_mV=4006, rssi=-68, b=78`)
- [x] Telegraf parser validated — Influx receives `fw_version`, `vbat_mV`, `rssi` fields
- [x] Grafana dashboard loaded via provisioning; all 6 panels render with live data
- [x] Pre-deployment data older than 2026-04-25T20:22:00Z purged from `sensor_reading`

## Follow-ups
- #12 — periodic heartbeat (boot count, uptime, reset reason)
- Token deployment hardening — repo `telegraf-combsense.conf` carries `<REDACTED>` placeholder; deploy step needs scripted substitution from `/root/.combsense-tsdb-creds`
- Dashboard deploy script (`deploy/tsdb/deploy-dashboard.sh`) to formalize the scp+UID-substitution pipeline currently done by hand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Over-the-air (OTA) firmware updates for sensor devices with automatic rollback on failure
  * Extended MQTT payload now includes firmware version, raw battery voltage (mV), and WiFi signal strength
  * Dashboard displays WiFi RSSI, battery voltage, and firmware version metrics
  * Firmware publishing workflow for device updates

* **Documentation**
  * Added comprehensive OTA implementation and design specifications
  * Added fleet visibility implementation and design documentation

* **Tests**
  * Added unit test coverage for battery conversion, OTA decisions, manifest parsing, SHA-256 verification, and payload serialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->